### PR TITLE
feat(trading): implement advanced order types and builder patterns

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Alpaca API Configuration
+# Copy this file to .env and fill in your credentials
+
+# Your Alpaca API key
+ALPACA_API_KEY=your_api_key_here
+
+# Your Alpaca API secret
+ALPACA_API_SECRET=your_api_secret_here
+
+# Base URL for the Alpaca API
+# Paper trading (recommended for testing):
+ALPACA_BASE_URL=https://paper-api.alpaca.markets
+# Live trading (use with caution):
+# ALPACA_BASE_URL=https://api.alpaca.markets
+
+# Data API URL (optional, defaults to data.alpaca.markets)
+# ALPACA_DATA_URL=https://data.alpaca.markets

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,36 +1,43 @@
-[package]
-name = "alpaca-rs"
-version = "0.1.0"
-edition = "2021"
-authors = ["Joaquin Bejar <jb@taunais.com>"]
-description = "This crate provides a client for the Alpaca Markets API"
-license = "MIT"
-readme = "README.md"
-repository = "https://github.com/joaquinbejar/alpaca-rs"
-homepage = "https://github.com/joaquinbejar/alpaca-rs"
-keywords = ["finance", "trading", "alpaca", "api", "markets"]
-categories = ["finance", "data-structures"]
-
-include = [
-    "benches/**/*",
-    "src/**/*",
-    "Cargo.toml",
-    "README.md",
-    "LICENSE",
-    "examples/**/*",
-    "tests/**/*",
-    "Makefile",
-    "rust-toolchain.toml",
-    "Draws/**/*",
-    "Docker/**/*",
+[workspace]
+members = [
+    "alpaca-base",
+    "alpaca-http", 
+    "alpaca-websocket",
 ]
+resolver = "2"
 
-
-
-[dependencies]
+[workspace.dependencies]
+# Core dependencies
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+tokio = { version = "1.48", features = ["full"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+thiserror = "2.0"
+chrono = { version = "0.4", features = ["serde"] }
+uuid = { version = "1.0", features = ["v4", "serde"] }
 
-[lib]
-name = "alpaca_rs"
-path = "src/lib.rs"
+# HTTP client dependencies
+reqwest = { version = "0.13", features = ["json"] }
+url = "2.5"
+urlencoding = "2.1"
+serde_urlencoded = "0.7"
+
+# WebSocket dependencies
+tokio-tungstenite = { version = "0.28", features = ["rustls-tls-webpki-roots"] }
+futures-util = "0.3"
+
+# Crypto dependencies
+hmac = "0.12"
+sha2 = "0.10"
+base64 = "0.22"
+
+# Utility dependencies
+rand = "0.9"
+dotenvy = "0.15"
+
+# Internal workspace dependencies
+alpaca-base = { path = "alpaca-base" }
+alpaca-http = { path = "alpaca-http" }
+alpaca-websocket = { path = "alpaca-websocket" }
 

--- a/README.md
+++ b/README.md
@@ -1,53 +1,114 @@
-<div style="text-align: center;">
-<img src="https://raw.githubusercontent.com/joaquinbejar/alpaca-rs/refs/heads/main/doc/images/logo.png" alt="alpaca-rs" style="width: 80%; height: 80%;">
-</div>
+# alpaca-rs
 
-[![Dual License](https://img.shields.io/badge/license-MIT-blue)](./LICENSE)
-[![Crates.io](https://img.shields.io/crates/v/alpaca-rs.svg)](https://crates.io/crates/alpaca-rs)
-[![Downloads](https://img.shields.io/crates/d/alpaca-rs.svg)](https://crates.io/crates/alpaca-rs)
-[![Stars](https://img.shields.io/github/stars/joaquinbejar/alpaca-rs.svg)](https://github.com/joaquinbejar/alpaca-rs/stargazers)
-[![Issues](https://img.shields.io/github/issues/joaquinbejar/alpaca-rs.svg)](https://github.com/joaquinbejar/alpaca-rs/issues)
-[![PRs](https://img.shields.io/github/issues-pr/joaquinbejar/alpaca-rs.svg)](https://github.com/joaquinbejar/alpaca-rs/pulls)
-[![Build Status](https://img.shields.io/github/workflow/status/joaquinbejar/alpaca-rs/CI)](https://github.com/joaquinbejar/alpaca-rs/actions)
-[![Coverage](https://img.shields.io/codecov/c/github/joaquinbejar/alpaca-rs)](https://codecov.io/gh/joaquinbejar/alpaca-rs)
-[![Dependencies](https://img.shields.io/librariesio/github/joaquinbejar/alpaca-rs)](https://libraries.io/github/joaquinbejar/alpaca-rs)
-[![Documentation](https://img.shields.io/badge/docs-latest-blue.svg)](https://docs.rs/alpaca-rs)
-[![Wiki](https://img.shields.io/badge/wiki-latest-blue.svg)](https://deepwiki.com/joaquinbejar/alpaca-rs)
+A comprehensive Rust client library for the [Alpaca Markets](https://alpaca.markets/) trading API.
 
-## Alpaca Markets API Client
+## Overview
 
-This crate provides a Rust client for the Alpaca Markets API.
+This workspace provides a complete Rust implementation for interacting with Alpaca's trading platform, including:
 
-### Example
+- **alpaca-base**: Core types, error handling, and utilities
+- **alpaca-http**: HTTP REST API client for trading and market data
+- **alpaca-websocket**: WebSocket client for real-time streaming data
 
-```rust
-use alpaca_rs::Client;
+## Features
 
-// Basic usage example will be added as the API is implemented
+- Full Trading API support (accounts, orders, positions, watchlists)
+- Market Data API (stocks, crypto bars, quotes, trades)
+- Advanced order types (bracket, OCO, OTO, trailing stop)
+- Real-time WebSocket streaming
+- Paper and live trading environments
+- Async/await support with Tokio
+
+## Installation
+
+Add the crates you need to your `Cargo.toml`:
+
+```toml
+[dependencies]
+alpaca-base = "0.2"
+alpaca-http = "0.2"
+alpaca-websocket = "0.1"
 ```
 
-## Contribution and Contact
+## Quick Start
 
-We welcome contributions to this project! If you would like to contribute, please follow these steps:
+```rust
+use alpaca_http::{AlpacaHttpClient, CreateOrderRequest};
+use alpaca_base::{Credentials, Environment, OrderSide, TakeProfit, StopLoss, OrderType};
 
-1. Fork the repository.
-2. Create a new branch for your feature or bug fix.
-3. Make your changes and ensure that the project still builds and all tests pass.
-4. Commit your changes and push your branch to your forked repository.
-5. Submit a pull request to the main repository.
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Create credentials and client
+    let credentials = Credentials::new(
+        "your_api_key".to_string(),
+        "your_api_secret".to_string(),
+    );
+    let client = AlpacaHttpClient::new(credentials, Environment::Paper)?;
 
-If you have any questions, issues, or would like to provide feedback, please feel free to contact the project maintainer:
+    // Get account information
+    let account = client.get_account().await?;
+    println!("Buying Power: ${}", account.buying_power);
 
-**Joaquin Bejar Garcia**
-- Email: jb@taunais.com
-- GitHub: [joaquinbejar](https://github.com/joaquinbejar)
+    // Create a simple market order
+    let order = CreateOrderRequest::market("AAPL", OrderSide::Buy, "1");
+    // let result = client.create_order(&order).await?;
 
-We appreciate your interest and look forward to your contributions!
+    // Create a bracket order with take-profit and stop-loss
+    let bracket_order = CreateOrderRequest::bracket(
+        "AAPL",
+        OrderSide::Buy,
+        "10",
+        OrderType::Limit,
+        TakeProfit::new("160.00"),
+        StopLoss::with_limit("140.00", "139.50"),
+    )
+    .with_limit_price("150.00")
+    .client_order_id("my-bracket-order");
+    // let result = client.create_order(&bracket_order).await?;
 
-## ✍️ License
+    Ok(())
+}
+```
 
-Licensed under MIT license
+## Order Types
 
-## Disclaimer
+The library supports all Alpaca order types:
 
-This software is not officially associated with IG Markets. Trading financial instruments carries risk, and this library is provided as-is without any guarantees. Always test thoroughly with a demo account before using in a live trading environment.
+- **Market**: Execute immediately at current market price
+- **Limit**: Execute at specified price or better
+- **Stop**: Trigger market order when stop price is reached
+- **Stop-Limit**: Trigger limit order when stop price is reached
+- **Trailing Stop**: Dynamic stop that follows the market
+
+### Advanced Order Classes
+
+- **Bracket**: Primary order with take-profit and stop-loss legs
+- **OCO (One-Cancels-Other)**: Two orders where filling one cancels the other
+- **OTO (One-Triggers-Other)**: Primary order that triggers a secondary order
+
+## Configuration
+
+Set up your API credentials using environment variables:
+
+```bash
+export ALPACA_API_KEY=your_api_key
+export ALPACA_API_SECRET=your_api_secret
+```
+
+Or use a `.env` file (see `.env.example`).
+
+## Examples
+
+Run the examples with:
+
+```bash
+cargo run --example trading_bracket_order
+```
+
+## License
+
+MIT License - see [LICENSE](LICENSE) for details.
+
+## Contributing
+
+Contributions are welcome! Please see the issues in `.issues/` for planned features.

--- a/alpaca-base/Cargo.toml
+++ b/alpaca-base/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "alpaca-base"
+version = "0.2.0"
+edition = "2024"
+authors = ["Joaquin Bejar <jb@taunais.com>"]
+description = "Base library with common structs, traits, and logic for Alpaca API clients"
+license = "MIT"
+readme = "README.md"
+repository = "https://github.com/joaquinbejar/alpaca-rs"
+homepage = "https://github.com/joaquinbejar/alpaca-rs"
+keywords = ["finance", "alpaca", "trading", "api"]
+categories = ["finance", "data-structures", "api-bindings"]
+
+[dependencies]
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+thiserror = { workspace = true }
+chrono = { workspace = true }
+uuid = { workspace = true }
+base64 = { workspace = true }
+rand = { workspace = true }
+urlencoding = { workspace = true }
+hmac = { workspace = true }
+sha2 = { workspace = true }
+tokio-tungstenite = { workspace = true }

--- a/alpaca-base/src/auth.rs
+++ b/alpaca-base/src/auth.rs
@@ -1,0 +1,101 @@
+use crate::error::{AlpacaError, Result};
+use base64::{Engine as _, engine::general_purpose};
+use chrono::{DateTime, Utc};
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+use std::collections::HashMap;
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Authentication credentials for Alpaca API
+#[derive(Debug, Clone)]
+pub struct Credentials {
+    pub api_key: String,
+    pub secret_key: String,
+}
+
+impl Credentials {
+    /// Create new credentials
+    pub fn new(api_key: String, secret_key: String) -> Self {
+        Self {
+            api_key,
+            secret_key,
+        }
+    }
+
+    /// Create credentials from environment variables
+    pub fn from_env() -> Result<Self> {
+        let api_key = std::env::var("ALPACA_API_KEY")
+            .map_err(|_| AlpacaError::Config("ALPACA_API_KEY not found".to_string()))?;
+        let secret_key = std::env::var("ALPACA_SECRET_KEY")
+            .map_err(|_| AlpacaError::Config("ALPACA_SECRET_KEY not found".to_string()))?;
+
+        Ok(Self::new(api_key, secret_key))
+    }
+
+    /// Generate authorization header for HTTP requests
+    pub fn auth_header(&self) -> String {
+        format!(
+            "Basic {}",
+            general_purpose::STANDARD.encode(format!("{}:{}", self.api_key, self.secret_key))
+        )
+    }
+
+    /// Generate HMAC signature for request authentication
+    pub fn sign_request(
+        &self,
+        method: &str,
+        path: &str,
+        body: &str,
+        timestamp: DateTime<Utc>,
+    ) -> Result<String> {
+        let timestamp_str = timestamp.timestamp().to_string();
+        let message = format!("{}{}{}{}", timestamp_str, method, path, body);
+
+        let mut mac = HmacSha256::new_from_slice(self.secret_key.as_bytes())
+            .map_err(|e| AlpacaError::Auth(format!("Invalid secret key: {}", e)))?;
+
+        mac.update(message.as_bytes());
+        let result = mac.finalize();
+
+        Ok(general_purpose::STANDARD.encode(result.into_bytes()))
+    }
+
+    /// Generate headers for authenticated requests
+    pub fn auth_headers(
+        &self,
+        method: &str,
+        path: &str,
+        body: &str,
+    ) -> Result<HashMap<String, String>> {
+        let timestamp = Utc::now();
+        let signature = self.sign_request(method, path, body, timestamp)?;
+
+        let mut headers = HashMap::new();
+        headers.insert("APCA-API-KEY-ID".to_string(), self.api_key.clone());
+        headers.insert("APCA-API-SECRET-KEY".to_string(), self.secret_key.clone());
+        headers.insert(
+            "APCA-API-TIMESTAMP".to_string(),
+            timestamp.timestamp().to_string(),
+        );
+        headers.insert("APCA-API-SIGNATURE".to_string(), signature);
+
+        Ok(headers)
+    }
+}
+
+/// OAuth token for API access
+#[derive(Debug, Clone)]
+pub struct OAuthToken {
+    pub access_token: String,
+    pub token_type: String,
+    pub expires_in: Option<u64>,
+    pub scope: Option<String>,
+}
+
+impl OAuthToken {
+    /// Create authorization header from OAuth token
+    pub fn auth_header(&self) -> String {
+        format!("{} {}", self.token_type, self.access_token)
+    }
+}

--- a/alpaca-base/src/error.rs
+++ b/alpaca-base/src/error.rs
@@ -1,0 +1,60 @@
+use thiserror::Error;
+
+/// Result type for Alpaca API operations
+pub type Result<T> = std::result::Result<T, AlpacaError>;
+
+/// Error types for the Alpaca API client
+#[derive(Error, Debug)]
+pub enum AlpacaError {
+    /// HTTP request errors
+    #[error("HTTP error: {0}")]
+    Http(String),
+
+    /// JSON parsing errors
+    #[error("JSON error: {0}")]
+    Json(String),
+
+    /// API errors returned by Alpaca
+    #[error("API error: {code} - {message}")]
+    Api { code: u16, message: String },
+
+    /// Authentication errors
+    #[error("Authentication error: {0}")]
+    Auth(String),
+
+    /// Invalid configuration
+    #[error("Configuration error: {0}")]
+    Config(String),
+
+    /// WebSocket errors
+    #[error("WebSocket error: {0}")]
+    WebSocket(String),
+
+    /// Rate limiting errors
+    #[error("Rate limit exceeded: {0}")]
+    RateLimit(String),
+
+    /// Network connectivity errors
+    #[error("Network error: {0}")]
+    Network(String),
+
+    /// Timeout errors
+    #[error("Timeout error: {0}")]
+    Timeout(String),
+
+    /// Invalid data format
+    #[error("Invalid data format: {0}")]
+    InvalidData(String),
+}
+
+impl From<serde_json::Error> for AlpacaError {
+    fn from(err: serde_json::Error) -> Self {
+        AlpacaError::Json(err.to_string())
+    }
+}
+
+impl From<tokio_tungstenite::tungstenite::Error> for AlpacaError {
+    fn from(err: tokio_tungstenite::tungstenite::Error) -> Self {
+        AlpacaError::WebSocket(err.to_string())
+    }
+}

--- a/alpaca-base/src/lib.rs
+++ b/alpaca-base/src/lib.rs
@@ -1,0 +1,15 @@
+//! # Alpaca Base
+//!
+//! Base library with common structs, traits, and logic for Alpaca API clients.
+//! This crate provides shared types, error handling, and utilities used across
+//! all Alpaca API client implementations.
+
+pub mod auth;
+pub mod error;
+pub mod types;
+pub mod utils;
+
+pub use auth::*;
+pub use error::{AlpacaError, Result};
+pub use types::*;
+pub use utils::*;

--- a/alpaca-base/src/types.rs
+++ b/alpaca-base/src/types.rs
@@ -1,0 +1,631 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Environment for Alpaca API
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Environment {
+    Paper,
+    Live,
+}
+
+impl Environment {
+    pub fn base_url(&self) -> &'static str {
+        match self {
+            Environment::Paper => "https://paper-api.alpaca.markets",
+            Environment::Live => "https://api.alpaca.markets",
+        }
+    }
+
+    pub fn data_url(&self) -> &'static str {
+        "https://data.alpaca.markets"
+    }
+
+    pub fn websocket_url(&self) -> &'static str {
+        match self {
+            Environment::Paper => "wss://paper-api.alpaca.markets/stream",
+            Environment::Live => "wss://api.alpaca.markets/stream",
+        }
+    }
+}
+
+/// Account information from Alpaca API
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Account {
+    pub id: Uuid,
+    pub account_number: String,
+    pub status: AccountStatus,
+    pub currency: String,
+    pub buying_power: String,
+    pub regt_buying_power: String,
+    pub daytrading_buying_power: String,
+    pub cash: String,
+    pub portfolio_value: String,
+    pub pattern_day_trader: bool,
+    pub trading_blocked: bool,
+    pub transfers_blocked: bool,
+    pub account_blocked: bool,
+    pub created_at: DateTime<Utc>,
+    pub trade_suspended_by_user: bool,
+    pub multiplier: String,
+    pub shorting_enabled: bool,
+    pub equity: String,
+    pub last_equity: String,
+    pub long_market_value: String,
+    pub short_market_value: String,
+    pub initial_margin: String,
+    pub maintenance_margin: String,
+    pub last_maintenance_margin: String,
+    pub sma: String,
+    pub daytrade_count: i32,
+}
+
+/// Account status
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum AccountStatus {
+    Onboarding,
+    SubmissionFailed,
+    Submitted,
+    AccountUpdated,
+    ApprovalPending,
+    Active,
+    Rejected,
+    Disabled,
+    AccountClosed,
+}
+
+/// Asset information
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Asset {
+    pub id: Uuid,
+    pub class: AssetClass,
+    pub exchange: String,
+    pub symbol: String,
+    pub name: String,
+    pub status: AssetStatus,
+    pub tradable: bool,
+    pub marginable: bool,
+    pub shortable: bool,
+    pub easy_to_borrow: bool,
+    pub fractionable: bool,
+}
+
+/// Asset class
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AssetClass {
+    UsEquity,
+    Crypto,
+}
+
+/// Asset status
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AssetStatus {
+    Active,
+    Inactive,
+}
+
+/// Order information
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Order {
+    pub id: Uuid,
+    pub client_order_id: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub submitted_at: Option<DateTime<Utc>>,
+    pub filled_at: Option<DateTime<Utc>>,
+    pub expired_at: Option<DateTime<Utc>>,
+    pub canceled_at: Option<DateTime<Utc>>,
+    pub failed_at: Option<DateTime<Utc>>,
+    pub replaced_at: Option<DateTime<Utc>>,
+    pub replaced_by: Option<Uuid>,
+    pub replaces: Option<Uuid>,
+    pub asset_id: Uuid,
+    pub symbol: String,
+    pub asset_class: AssetClass,
+    pub notional: Option<String>,
+    pub qty: Option<String>,
+    pub filled_qty: String,
+    pub filled_avg_price: Option<String>,
+    pub order_class: OrderClass,
+    pub order_type: OrderType,
+    pub side: OrderSide,
+    pub time_in_force: TimeInForce,
+    pub limit_price: Option<String>,
+    pub stop_price: Option<String>,
+    pub status: OrderStatus,
+    pub extended_hours: bool,
+    pub legs: Option<Vec<Order>>,
+    pub trail_percent: Option<String>,
+    pub trail_price: Option<String>,
+    pub hwm: Option<String>,
+}
+
+/// Order class
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum OrderClass {
+    Simple,
+    Bracket,
+    Oco,
+    Oto,
+}
+
+/// Order type
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum OrderType {
+    #[default]
+    Market,
+    Limit,
+    Stop,
+    StopLimit,
+    TrailingStop,
+}
+
+/// Order side
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum OrderSide {
+    #[default]
+    Buy,
+    Sell,
+}
+
+/// Time in force for orders.
+///
+/// Specifies how long an order remains active before it is executed or expires.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum TimeInForce {
+    /// Day order - valid for the trading day.
+    #[default]
+    Day,
+    /// Good Till Canceled - remains active until filled or canceled.
+    Gtc,
+    /// Immediate Or Cancel - executes immediately, cancels unfilled portion.
+    Ioc,
+    /// Fill Or Kill - must be filled entirely immediately or canceled.
+    Fok,
+    /// Market On Open - executes at market open.
+    Opg,
+    /// Market On Close - executes at market close.
+    Cls,
+    /// Good Till Date - remains active until specified date.
+    Gtd,
+}
+
+/// Order status
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum OrderStatus {
+    New,
+    PartiallyFilled,
+    Filled,
+    DoneForDay,
+    Canceled,
+    Expired,
+    Replaced,
+    PendingCancel,
+    PendingReplace,
+    PendingReview,
+    Accepted,
+    PendingNew,
+    AcceptedForBidding,
+    Stopped,
+    Rejected,
+    Suspended,
+    Calculated,
+}
+
+/// Position information
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Position {
+    pub asset_id: Uuid,
+    pub symbol: String,
+    pub exchange: String,
+    pub asset_class: AssetClass,
+    pub avg_entry_price: String,
+    pub qty: String,
+    pub side: PositionSide,
+    pub market_value: String,
+    pub cost_basis: String,
+    pub unrealized_pl: String,
+    pub unrealized_plpc: String,
+    pub unrealized_intraday_pl: String,
+    pub unrealized_intraday_plpc: String,
+    pub current_price: String,
+    pub lastday_price: String,
+    pub change_today: String,
+}
+
+/// Position side
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PositionSide {
+    Long,
+    Short,
+}
+
+/// Market data bar
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Bar {
+    pub timestamp: DateTime<Utc>,
+    pub open: f64,
+    pub high: f64,
+    pub low: f64,
+    pub close: f64,
+    pub volume: u64,
+    pub trade_count: Option<u64>,
+    pub vwap: Option<f64>,
+}
+
+/// Market data quote
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Quote {
+    pub timestamp: DateTime<Utc>,
+    pub timeframe: String,
+    pub bid_price: f64,
+    pub bid_size: u32,
+    pub ask_price: f64,
+    pub ask_size: u32,
+    pub bid_exchange: String,
+    pub ask_exchange: String,
+}
+
+/// Market data trade
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Trade {
+    pub timestamp: DateTime<Utc>,
+    pub price: f64,
+    pub size: u32,
+    pub exchange: String,
+    pub conditions: Vec<String>,
+    pub id: u64,
+}
+
+/// Timeframe for market data
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum Timeframe {
+    #[serde(rename = "1Min")]
+    OneMinute,
+    #[serde(rename = "5Min")]
+    FiveMinutes,
+    #[serde(rename = "15Min")]
+    FifteenMinutes,
+    #[serde(rename = "30Min")]
+    ThirtyMinutes,
+    #[serde(rename = "1Hour")]
+    OneHour,
+    #[serde(rename = "1Day")]
+    OneDay,
+    #[serde(rename = "1Week")]
+    OneWeek,
+    #[serde(rename = "1Month")]
+    OneMonth,
+}
+
+/// Watchlist information
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Watchlist {
+    pub id: Uuid,
+    pub account_id: Uuid,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub name: String,
+    pub assets: Vec<Asset>,
+}
+
+/// Calendar information
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Calendar {
+    pub date: String,
+    pub open: String,
+    pub close: String,
+    pub session_open: String,
+    pub session_close: String,
+}
+
+/// Clock information
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Clock {
+    pub timestamp: DateTime<Utc>,
+    pub is_open: bool,
+    pub next_open: DateTime<Utc>,
+    pub next_close: DateTime<Utc>,
+}
+
+/// Portfolio history
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct PortfolioHistory {
+    pub timestamp: Vec<i64>,
+    pub equity: Vec<Option<f64>>,
+    pub profit_loss: Vec<Option<f64>>,
+    pub profit_loss_pct: Vec<Option<f64>>,
+    pub base_value: f64,
+    pub timeframe: String,
+}
+
+/// Account activity
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct AccountActivity {
+    pub id: String,
+    pub account_id: Uuid,
+    pub activity_type: ActivityType,
+    pub date: String,
+    pub net_amount: String,
+    pub symbol: Option<String>,
+    pub qty: Option<String>,
+    pub per_share_amount: Option<String>,
+}
+
+/// Activity type
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum ActivityType {
+    Fill,
+    TransactionFee,
+    Misc,
+    AcatsIn,
+    AcatsOut,
+    Csd,
+    Csr,
+    Div,
+    Divcgl,
+    Divcgs,
+    Divfee,
+    Divft,
+    Divnra,
+    Divroc,
+    Divtw,
+    Divtxex,
+    Int,
+    Jnlc,
+    Jnls,
+    Ma,
+    Nc,
+    Opasn,
+    Opexp,
+    Opxrc,
+    Pta,
+    Ptc,
+    Reorg,
+    Sc,
+    Sso,
+    Tc,
+}
+
+/// News article
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct NewsArticle {
+    pub id: i64,
+    pub headline: String,
+    pub author: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub summary: String,
+    pub content: String,
+    pub url: String,
+    pub symbols: Vec<String>,
+}
+
+/// Crypto wallet
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CryptoWallet {
+    pub id: Uuid,
+    pub name: String,
+    pub currency: String,
+    pub balance: String,
+    pub available_balance: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Position intent for options orders.
+///
+/// Specifies the intent of an options order in relation to opening or closing positions.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PositionIntent {
+    /// Buy to open a new long position.
+    BuyToOpen,
+    /// Buy to close an existing short position.
+    BuyToClose,
+    /// Sell to open a new short position.
+    SellToOpen,
+    /// Sell to close an existing long position.
+    SellToClose,
+}
+
+/// Take profit configuration for bracket orders.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct TakeProfit {
+    /// The limit price for the take profit leg.
+    pub limit_price: String,
+}
+
+impl TakeProfit {
+    /// Creates a new take profit configuration.
+    #[must_use]
+    pub fn new(limit_price: impl Into<String>) -> Self {
+        Self {
+            limit_price: limit_price.into(),
+        }
+    }
+}
+
+/// Stop loss configuration for bracket orders.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct StopLoss {
+    /// The stop price that triggers the stop loss.
+    pub stop_price: String,
+    /// Optional limit price for a stop-limit order.
+    pub limit_price: Option<String>,
+}
+
+impl StopLoss {
+    /// Creates a new stop loss configuration with only a stop price (market order when triggered).
+    #[must_use]
+    pub fn new(stop_price: impl Into<String>) -> Self {
+        Self {
+            stop_price: stop_price.into(),
+            limit_price: None,
+        }
+    }
+
+    /// Creates a new stop loss configuration with both stop and limit prices (stop-limit order).
+    #[must_use]
+    pub fn with_limit(stop_price: impl Into<String>, limit_price: impl Into<String>) -> Self {
+        Self {
+            stop_price: stop_price.into(),
+            limit_price: Some(limit_price.into()),
+        }
+    }
+}
+
+/// Sort direction for order queries.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum SortDirection {
+    /// Ascending order (oldest first).
+    Asc,
+    /// Descending order (newest first).
+    Desc,
+}
+
+/// Order query status filter.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum OrderQueryStatus {
+    /// Only open orders.
+    Open,
+    /// Only closed orders.
+    Closed,
+    /// All orders.
+    All,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_take_profit_new() {
+        let tp = TakeProfit::new("150.00");
+        assert_eq!(tp.limit_price, "150.00");
+    }
+
+    #[test]
+    fn test_stop_loss_new() {
+        let sl = StopLoss::new("95.00");
+        assert_eq!(sl.stop_price, "95.00");
+        assert!(sl.limit_price.is_none());
+    }
+
+    #[test]
+    fn test_stop_loss_with_limit() {
+        let sl = StopLoss::with_limit("95.00", "94.50");
+        assert_eq!(sl.stop_price, "95.00");
+        assert_eq!(sl.limit_price, Some("94.50".to_string()));
+    }
+
+    #[test]
+    fn test_time_in_force_serialization() {
+        let tif = TimeInForce::Gtc;
+        let json = serde_json::to_string(&tif).unwrap();
+        assert_eq!(json, "\"gtc\"");
+
+        let tif = TimeInForce::Gtd;
+        let json = serde_json::to_string(&tif).unwrap();
+        assert_eq!(json, "\"gtd\"");
+    }
+
+    #[test]
+    fn test_time_in_force_deserialization() {
+        let tif: TimeInForce = serde_json::from_str("\"day\"").unwrap();
+        assert_eq!(tif, TimeInForce::Day);
+
+        let tif: TimeInForce = serde_json::from_str("\"gtc\"").unwrap();
+        assert_eq!(tif, TimeInForce::Gtc);
+
+        let tif: TimeInForce = serde_json::from_str("\"ioc\"").unwrap();
+        assert_eq!(tif, TimeInForce::Ioc);
+    }
+
+    #[test]
+    fn test_order_class_serialization() {
+        let oc = OrderClass::Bracket;
+        let json = serde_json::to_string(&oc).unwrap();
+        assert_eq!(json, "\"bracket\"");
+
+        let oc = OrderClass::Oco;
+        let json = serde_json::to_string(&oc).unwrap();
+        assert_eq!(json, "\"oco\"");
+
+        let oc = OrderClass::Oto;
+        let json = serde_json::to_string(&oc).unwrap();
+        assert_eq!(json, "\"oto\"");
+    }
+
+    #[test]
+    fn test_position_intent_serialization() {
+        let pi = PositionIntent::BuyToOpen;
+        let json = serde_json::to_string(&pi).unwrap();
+        assert_eq!(json, "\"buy_to_open\"");
+
+        let pi = PositionIntent::SellToClose;
+        let json = serde_json::to_string(&pi).unwrap();
+        assert_eq!(json, "\"sell_to_close\"");
+    }
+
+    #[test]
+    fn test_order_query_status_serialization() {
+        let status = OrderQueryStatus::Open;
+        let json = serde_json::to_string(&status).unwrap();
+        assert_eq!(json, "\"open\"");
+
+        let status = OrderQueryStatus::All;
+        let json = serde_json::to_string(&status).unwrap();
+        assert_eq!(json, "\"all\"");
+    }
+
+    #[test]
+    fn test_sort_direction_serialization() {
+        let dir = SortDirection::Asc;
+        let json = serde_json::to_string(&dir).unwrap();
+        assert_eq!(json, "\"asc\"");
+
+        let dir = SortDirection::Desc;
+        let json = serde_json::to_string(&dir).unwrap();
+        assert_eq!(json, "\"desc\"");
+    }
+
+    #[test]
+    fn test_order_side_serialization() {
+        let side = OrderSide::Buy;
+        let json = serde_json::to_string(&side).unwrap();
+        assert_eq!(json, "\"buy\"");
+
+        let side = OrderSide::Sell;
+        let json = serde_json::to_string(&side).unwrap();
+        assert_eq!(json, "\"sell\"");
+    }
+
+    #[test]
+    fn test_order_type_serialization() {
+        let ot = OrderType::Market;
+        let json = serde_json::to_string(&ot).unwrap();
+        assert_eq!(json, "\"market\"");
+
+        let ot = OrderType::StopLimit;
+        let json = serde_json::to_string(&ot).unwrap();
+        assert_eq!(json, "\"stop_limit\"");
+
+        let ot = OrderType::TrailingStop;
+        let json = serde_json::to_string(&ot).unwrap();
+        assert_eq!(json, "\"trailing_stop\"");
+    }
+}

--- a/alpaca-base/src/utils.rs
+++ b/alpaca-base/src/utils.rs
@@ -1,0 +1,296 @@
+use crate::error::{AlpacaError, Result};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use uuid::Uuid;
+
+/// Generate a random client order ID
+pub fn generate_client_order_id() -> String {
+    Uuid::new_v4().to_string()
+}
+
+/// Parse a string to a decimal value with validation
+pub fn parse_decimal(value: &str) -> Result<f64> {
+    value
+        .parse::<f64>()
+        .map_err(|_| AlpacaError::InvalidData(format!("Invalid decimal value: {}", value)))
+}
+
+/// Format decimal value to string with specified precision
+pub fn format_decimal(value: f64, precision: usize) -> String {
+    format!("{:.prec$}", value, prec = precision)
+}
+
+/// Validate symbol format
+pub fn validate_symbol(symbol: &str) -> Result<()> {
+    if symbol.is_empty() {
+        return Err(AlpacaError::InvalidData(
+            "Symbol cannot be empty".to_string(),
+        ));
+    }
+
+    if symbol.len() > 12 {
+        return Err(AlpacaError::InvalidData("Symbol too long".to_string()));
+    }
+
+    if !symbol
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '-')
+    {
+        return Err(AlpacaError::InvalidData(
+            "Invalid symbol format".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Validate quantity value
+pub fn validate_quantity(qty: &str) -> Result<()> {
+    let value = parse_decimal(qty)?;
+
+    if value <= 0.0 {
+        return Err(AlpacaError::InvalidData(
+            "Quantity must be positive".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Validate price value
+pub fn validate_price(price: &str) -> Result<()> {
+    let value = parse_decimal(price)?;
+
+    if value <= 0.0 {
+        return Err(AlpacaError::InvalidData(
+            "Price must be positive".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Convert timestamp to RFC3339 format
+pub fn timestamp_to_rfc3339(timestamp: DateTime<Utc>) -> String {
+    timestamp.to_rfc3339()
+}
+
+/// Parse RFC3339 timestamp
+pub fn parse_rfc3339(timestamp: &str) -> Result<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(timestamp)
+        .map(|dt| dt.with_timezone(&Utc))
+        .map_err(|e| AlpacaError::InvalidData(format!("Invalid timestamp format: {}", e)))
+}
+
+/// Rate limiter for API requests
+#[derive(Debug)]
+pub struct RateLimiter {
+    requests_per_minute: u32,
+    last_reset: DateTime<Utc>,
+    current_count: u32,
+}
+
+impl RateLimiter {
+    /// Create a new rate limiter
+    pub fn new(requests_per_minute: u32) -> Self {
+        Self {
+            requests_per_minute,
+            last_reset: Utc::now(),
+            current_count: 0,
+        }
+    }
+
+    /// Check if a request can be made
+    pub fn can_make_request(&mut self) -> bool {
+        let now = Utc::now();
+
+        // Reset counter if a minute has passed
+        if now.signed_duration_since(self.last_reset).num_seconds() >= 60 {
+            self.last_reset = now;
+            self.current_count = 0;
+        }
+
+        if self.current_count < self.requests_per_minute {
+            self.current_count += 1;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Get remaining requests in current window
+    pub fn remaining_requests(&self) -> u32 {
+        self.requests_per_minute.saturating_sub(self.current_count)
+    }
+}
+
+/// Pagination parameters for API requests
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Pagination {
+    pub page_token: Option<String>,
+    pub limit: Option<u32>,
+}
+
+impl Default for Pagination {
+    fn default() -> Self {
+        Self {
+            page_token: None,
+            limit: Some(100),
+        }
+    }
+}
+
+/// Response wrapper with pagination information
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PaginatedResponse<T> {
+    pub data: Vec<T>,
+    pub next_page_token: Option<String>,
+}
+
+/// Retry configuration for API requests
+#[derive(Debug, Clone)]
+pub struct RetryConfig {
+    pub max_retries: u32,
+    pub initial_delay_ms: u64,
+    pub max_delay_ms: u64,
+    pub backoff_multiplier: f64,
+}
+
+impl Default for RetryConfig {
+    fn default() -> Self {
+        Self {
+            max_retries: 3,
+            initial_delay_ms: 1000,
+            max_delay_ms: 30000,
+            backoff_multiplier: 2.0,
+        }
+    }
+}
+
+/// Logger configuration
+pub fn init_logger() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .try_init()
+        .map_err(|e| AlpacaError::Config(format!("Failed to initialize logger: {}", e)))
+}
+
+/// URL builder helper
+#[derive(Debug)]
+pub struct UrlBuilder {
+    base_url: String,
+    path: String,
+    query_params: Vec<(String, String)>,
+}
+
+impl UrlBuilder {
+    /// Create a new URL builder
+    pub fn new(base_url: &str) -> Self {
+        Self {
+            base_url: base_url.to_string(),
+            path: String::new(),
+            query_params: Vec::new(),
+        }
+    }
+
+    /// Add path segment
+    pub fn path(mut self, segment: &str) -> Self {
+        if !self.path.is_empty() && !self.path.ends_with('/') {
+            self.path.push('/');
+        }
+        self.path.push_str(segment);
+        self
+    }
+
+    /// Add query parameter
+    pub fn query<T: fmt::Display>(mut self, key: &str, value: T) -> Self {
+        self.query_params.push((key.to_string(), value.to_string()));
+        self
+    }
+
+    /// Add optional query parameter
+    pub fn query_opt<T: fmt::Display>(self, key: &str, value: Option<T>) -> Self {
+        match value {
+            Some(v) => self.query(key, v),
+            None => self,
+        }
+    }
+
+    /// Build the final URL
+    pub fn build(self) -> Result<String> {
+        let mut url = format!(
+            "{}/{}",
+            self.base_url.trim_end_matches('/'),
+            self.path.trim_start_matches('/')
+        );
+
+        if !self.query_params.is_empty() {
+            url.push('?');
+            for (i, (key, value)) in self.query_params.iter().enumerate() {
+                if i > 0 {
+                    url.push('&');
+                }
+                url.push_str(&urlencoding::encode(key));
+                url.push('=');
+                url.push_str(&urlencoding::encode(value));
+            }
+        }
+
+        Ok(url)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_generate_client_order_id() {
+        let id1 = generate_client_order_id();
+        let id2 = generate_client_order_id();
+        assert_ne!(id1, id2);
+        assert!(Uuid::parse_str(&id1).is_ok());
+    }
+
+    #[test]
+    fn test_validate_symbol() {
+        assert!(validate_symbol("AAPL").is_ok());
+        assert!(validate_symbol("BRK.A").is_ok());
+        assert!(validate_symbol("").is_err());
+        assert!(validate_symbol("VERYLONGSYMBOL").is_err());
+    }
+
+    #[test]
+    fn test_validate_quantity() {
+        assert!(validate_quantity("100").is_ok());
+        assert!(validate_quantity("0.5").is_ok());
+        assert!(validate_quantity("0").is_err());
+        assert!(validate_quantity("-10").is_err());
+        assert!(validate_quantity("invalid").is_err());
+    }
+
+    #[test]
+    fn test_url_builder() {
+        let url = UrlBuilder::new("https://api.example.com")
+            .path("v2/orders")
+            .query("symbol", "AAPL")
+            .query("limit", 100)
+            .build()
+            .unwrap();
+
+        assert_eq!(
+            url,
+            "https://api.example.com/v2/orders?symbol=AAPL&limit=100"
+        );
+    }
+
+    #[test]
+    fn test_rate_limiter() {
+        let mut limiter = RateLimiter::new(2);
+        assert!(limiter.can_make_request());
+        assert!(limiter.can_make_request());
+        assert!(!limiter.can_make_request());
+        assert_eq!(limiter.remaining_requests(), 0);
+    }
+}

--- a/alpaca-http/Cargo.toml
+++ b/alpaca-http/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "alpaca-http"
+version = "0.2.0"
+edition = "2024"
+authors = ["Joaquin Bejar <jb@taunais.com>"]
+description = "HTTP REST API client for Alpaca trading platform"
+license = "MIT"
+readme = "README.md"
+repository = "https://github.com/joaquinbejar/alpaca-rs"
+homepage = "https://github.com/joaquinbejar/alpaca-rs"
+keywords = ["finance", "alpaca", "trading", "api", "http"]
+categories = ["finance", "api-bindings", "web-programming::http-client"]
+
+[dependencies]
+alpaca-base = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tracing = { workspace = true }
+reqwest = { workspace = true }
+tokio = { workspace = true }
+thiserror = { workspace = true }
+url = { workspace = true }
+urlencoding = { workspace = true }
+serde_urlencoded = { workspace = true }
+chrono = { workspace = true }
+uuid = { workspace = true }
+
+[dev-dependencies]
+dotenvy = { workspace = true }

--- a/alpaca-http/src/client.rs
+++ b/alpaca-http/src/client.rs
@@ -1,0 +1,279 @@
+use alpaca_base::{AlpacaError, Result, auth::Credentials, types::Environment, utils::UrlBuilder};
+use reqwest::{Client, Method, RequestBuilder, Response};
+use serde::{Serialize, de::DeserializeOwned};
+use std::time::Duration;
+use tracing::{debug, error};
+
+/// HTTP client for Alpaca API
+#[derive(Debug, Clone)]
+pub struct AlpacaHttpClient {
+    client: Client,
+    credentials: Credentials,
+    environment: Environment,
+    base_url: String,
+    data_url: String,
+}
+
+impl AlpacaHttpClient {
+    /// Create a new HTTP client
+    pub fn new(credentials: Credentials, environment: Environment) -> Result<Self> {
+        let client = Client::builder()
+            .timeout(Duration::from_secs(30))
+            .user_agent("alpaca-rs/0.1.0")
+            .build()
+            .map_err(|e| AlpacaError::Http(e.to_string()))?;
+
+        Ok(Self {
+            client,
+            credentials,
+            base_url: environment.base_url().to_string(),
+            data_url: environment.data_url().to_string(),
+            environment,
+        })
+    }
+
+    /// Create a new client from environment variables
+    pub fn from_env(environment: Environment) -> Result<Self> {
+        let credentials = Credentials::from_env()?;
+        Self::new(credentials, environment)
+    }
+
+    /// Make a GET request
+    pub async fn get<T>(&self, path: &str) -> Result<T>
+    where
+        T: DeserializeOwned,
+    {
+        self.request::<T, ()>(Method::GET, path, None).await
+    }
+
+    /// Make a GET request with query parameters
+    pub async fn get_with_params<T, P>(&self, path: &str, params: &P) -> Result<T>
+    where
+        T: DeserializeOwned,
+        P: Serialize,
+    {
+        // Serialize params to query string
+        let query_string = serde_urlencoded::to_string(params)
+            .map_err(|e| AlpacaError::Json(format!("Failed to serialize query params: {}", e)))?;
+
+        let url = if query_string.is_empty() {
+            self.build_url(path)?
+        } else {
+            format!("{}?{}", self.build_url(path)?, query_string)
+        };
+
+        let request = self.client.get(&url).headers(self.build_headers()?);
+
+        self.execute_request(request).await
+    }
+
+    /// Make a POST request
+    pub async fn post<T, B>(&self, path: &str, body: &B) -> Result<T>
+    where
+        T: DeserializeOwned,
+        B: Serialize,
+    {
+        self.request(Method::POST, path, Some(body)).await
+    }
+
+    /// Make a PUT request
+    pub async fn put<T, B>(&self, path: &str, body: &B) -> Result<T>
+    where
+        T: DeserializeOwned,
+        B: Serialize,
+    {
+        self.request(Method::PUT, path, Some(body)).await
+    }
+
+    /// Make a PATCH request
+    pub async fn patch<T, B>(&self, path: &str, body: &B) -> Result<T>
+    where
+        T: DeserializeOwned,
+        B: Serialize,
+    {
+        self.request(Method::PATCH, path, Some(body)).await
+    }
+
+    /// Make a DELETE request
+    pub async fn delete<T>(&self, path: &str) -> Result<T>
+    where
+        T: DeserializeOwned,
+    {
+        self.request::<T, ()>(Method::DELETE, path, None).await
+    }
+
+    /// Make a generic request
+    async fn request<T, B>(&self, method: Method, path: &str, body: Option<&B>) -> Result<T>
+    where
+        T: DeserializeOwned,
+        B: Serialize,
+    {
+        let url = self.build_url(path)?;
+        let mut request = self
+            .client
+            .request(method.clone(), &url)
+            .headers(self.build_headers()?);
+
+        if let Some(body) = body {
+            request = request.json(body);
+        }
+
+        debug!("Making {} request to {}", method, url);
+        self.execute_request(request).await
+    }
+
+    /// Execute the request and handle the response
+    async fn execute_request<T>(&self, request: RequestBuilder) -> Result<T>
+    where
+        T: DeserializeOwned,
+    {
+        let response = request
+            .send()
+            .await
+            .map_err(|e| AlpacaError::Network(e.to_string()))?;
+
+        self.handle_response(response).await
+    }
+
+    /// Handle the HTTP response
+    async fn handle_response<T>(&self, response: Response) -> Result<T>
+    where
+        T: DeserializeOwned,
+    {
+        let status = response.status();
+        let headers = response.headers().clone();
+
+        debug!("Response status: {}", status);
+
+        // Check for rate limiting
+        if status == 429 {
+            let retry_after = headers
+                .get("retry-after")
+                .and_then(|h| h.to_str().ok())
+                .unwrap_or("60");
+            return Err(AlpacaError::RateLimit(format!(
+                "Retry after {} seconds",
+                retry_after
+            )));
+        }
+
+        // Get response text for error handling
+        let response_text = response
+            .text()
+            .await
+            .map_err(|e| AlpacaError::Network(e.to_string()))?;
+
+        if !status.is_success() {
+            error!("API error response: {}", response_text);
+
+            // Try to parse error response
+            if let Ok(error_response) = serde_json::from_str::<serde_json::Value>(&response_text) {
+                let message = error_response
+                    .get("message")
+                    .or_else(|| error_response.get("error"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or(&response_text);
+
+                return Err(AlpacaError::Api {
+                    code: status.as_u16(),
+                    message: message.to_string(),
+                });
+            }
+
+            return Err(AlpacaError::Api {
+                code: status.as_u16(),
+                message: response_text,
+            });
+        }
+
+        // Parse successful response
+        serde_json::from_str(&response_text).map_err(|e| {
+            AlpacaError::Json(format!(
+                "Failed to parse response: {} - Response: {}",
+                e, response_text
+            ))
+        })
+    }
+
+    /// Build the full URL for a request
+    fn build_url(&self, path: &str) -> Result<String> {
+        // Use data URL for market data endpoints
+        let base_url = if path.starts_with("/v2/stocks") || path.starts_with("/v1beta1/crypto") {
+            &self.data_url
+        } else {
+            &self.base_url
+        };
+
+        UrlBuilder::new(base_url)
+            .path(path.trim_start_matches('/'))
+            .build()
+    }
+
+    /// Build authentication headers
+    fn build_headers(&self) -> Result<reqwest::header::HeaderMap> {
+        let mut headers = reqwest::header::HeaderMap::new();
+
+        headers.insert(
+            "APCA-API-KEY-ID",
+            self.credentials
+                .api_key
+                .parse()
+                .map_err(|_| AlpacaError::Auth("Invalid API key format".to_string()))?,
+        );
+
+        headers.insert(
+            "APCA-API-SECRET-KEY",
+            self.credentials
+                .secret_key
+                .parse()
+                .map_err(|_| AlpacaError::Auth("Invalid secret key format".to_string()))?,
+        );
+
+        headers.insert("Content-Type", "application/json".parse().unwrap());
+
+        Ok(headers)
+    }
+
+    /// Get the current environment
+    pub fn environment(&self) -> &Environment {
+        &self.environment
+    }
+
+    /// Get the base URL
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    /// Get the data URL
+    pub fn data_url(&self) -> &str {
+        &self.data_url
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alpaca_base::types::Environment;
+
+    #[test]
+    fn test_build_url() {
+        let credentials = Credentials::new("test_key".to_string(), "test_secret".to_string());
+        let client = AlpacaHttpClient::new(credentials, Environment::Paper).unwrap();
+
+        let url = client.build_url("/v2/account").unwrap();
+        assert_eq!(url, "https://paper-api.alpaca.markets/v2/account");
+
+        let data_url = client.build_url("/v2/stocks/AAPL/bars").unwrap();
+        assert_eq!(data_url, "https://data.alpaca.markets/v2/stocks/AAPL/bars");
+    }
+
+    #[test]
+    fn test_environment_urls() {
+        assert_eq!(
+            Environment::Paper.base_url(),
+            "https://paper-api.alpaca.markets"
+        );
+        assert_eq!(Environment::Live.base_url(), "https://api.alpaca.markets");
+        assert_eq!(Environment::Paper.data_url(), "https://data.alpaca.markets");
+    }
+}

--- a/alpaca-http/src/endpoints.rs
+++ b/alpaca-http/src/endpoints.rs
@@ -1,0 +1,1089 @@
+//! HTTP API endpoints for Alpaca trading platform.
+//!
+//! This module provides implementations for all Alpaca REST API endpoints
+//! including account management, order operations, position management,
+//! market data, and more.
+
+use crate::client::AlpacaHttpClient;
+use alpaca_base::{Result, types::*};
+use chrono::{DateTime, NaiveDate, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+impl AlpacaHttpClient {
+    // Account endpoints
+
+    /// Get account information
+    pub async fn get_account(&self) -> Result<Account> {
+        self.get("/v2/account").await
+    }
+
+    /// Get account configurations
+    pub async fn get_account_configurations(&self) -> Result<AccountConfigurations> {
+        self.get("/v2/account/configurations").await
+    }
+
+    /// Update account configurations
+    pub async fn update_account_configurations(
+        &self,
+        config: &AccountConfigurations,
+    ) -> Result<AccountConfigurations> {
+        self.patch("/v2/account/configurations", config).await
+    }
+
+    /// Get account activities
+    pub async fn get_account_activities(
+        &self,
+        params: &ActivityParams,
+    ) -> Result<Vec<AccountActivity>> {
+        self.get_with_params("/v2/account/activities", params).await
+    }
+
+    /// Get portfolio history
+    pub async fn get_portfolio_history(
+        &self,
+        params: &PortfolioHistoryParams,
+    ) -> Result<PortfolioHistory> {
+        self.get_with_params("/v2/account/portfolio/history", params)
+            .await
+    }
+
+    // Asset endpoints
+
+    /// Get all assets
+    pub async fn get_assets(&self, params: &AssetParams) -> Result<Vec<Asset>> {
+        self.get_with_params("/v2/assets", params).await
+    }
+
+    /// Get asset by ID
+    pub async fn get_asset(&self, asset_id: &Uuid) -> Result<Asset> {
+        self.get(&format!("/v2/assets/{}", asset_id)).await
+    }
+
+    /// Get asset by symbol
+    pub async fn get_asset_by_symbol(&self, symbol: &str) -> Result<Asset> {
+        self.get(&format!("/v2/assets/{}", symbol)).await
+    }
+
+    // Order endpoints
+
+    /// Get all orders
+    pub async fn get_orders(&self, params: &OrderParams) -> Result<Vec<Order>> {
+        self.get_with_params("/v2/orders", params).await
+    }
+
+    /// Create a new order
+    pub async fn create_order(&self, order: &CreateOrderRequest) -> Result<Order> {
+        self.post("/v2/orders", order).await
+    }
+
+    /// Get order by ID
+    pub async fn get_order(&self, order_id: &Uuid) -> Result<Order> {
+        self.get(&format!("/v2/orders/{}", order_id)).await
+    }
+
+    /// Get order by client order ID
+    pub async fn get_order_by_client_id(&self, client_order_id: &str) -> Result<Order> {
+        self.get(&format!(
+            "/v2/orders:by_client_order_id?client_order_id={}",
+            client_order_id
+        ))
+        .await
+    }
+
+    /// Replace an order
+    pub async fn replace_order(
+        &self,
+        order_id: &Uuid,
+        order: &ReplaceOrderRequest,
+    ) -> Result<Order> {
+        self.patch(&format!("/v2/orders/{}", order_id), order).await
+    }
+
+    /// Cancel an order
+    pub async fn cancel_order(&self, order_id: &Uuid) -> Result<()> {
+        self.delete(&format!("/v2/orders/{}", order_id)).await
+    }
+
+    /// Cancel all orders
+    pub async fn cancel_all_orders(&self) -> Result<Vec<CancelOrderResponse>> {
+        self.delete("/v2/orders").await
+    }
+
+    // Position endpoints
+
+    /// Get all positions
+    pub async fn get_positions(&self) -> Result<Vec<Position>> {
+        self.get("/v2/positions").await
+    }
+
+    /// Get position by symbol
+    pub async fn get_position(&self, symbol: &str) -> Result<Position> {
+        self.get(&format!("/v2/positions/{}", symbol)).await
+    }
+
+    /// Close all positions
+    pub async fn close_all_positions(
+        &self,
+        cancel_orders: bool,
+    ) -> Result<Vec<ClosePositionResponse>> {
+        let url = format!("/v2/positions?cancel_orders={}", cancel_orders);
+        self.delete(&url).await
+    }
+
+    /// Close position by symbol
+    pub async fn close_position(
+        &self,
+        symbol: &str,
+        _params: &ClosePositionRequest,
+    ) -> Result<Order> {
+        self.delete(&format!("/v2/positions/{}", symbol)).await
+    }
+
+    // Watchlist endpoints
+
+    /// Get all watchlists
+    pub async fn get_watchlists(&self) -> Result<Vec<Watchlist>> {
+        self.get("/v2/watchlists").await
+    }
+
+    /// Create a new watchlist
+    pub async fn create_watchlist(&self, watchlist: &CreateWatchlistRequest) -> Result<Watchlist> {
+        self.post("/v2/watchlists", watchlist).await
+    }
+
+    /// Get watchlist by ID
+    pub async fn get_watchlist(&self, watchlist_id: &Uuid) -> Result<Watchlist> {
+        self.get(&format!("/v2/watchlists/{}", watchlist_id)).await
+    }
+
+    /// Update watchlist
+    pub async fn update_watchlist(
+        &self,
+        watchlist_id: &Uuid,
+        watchlist: &UpdateWatchlistRequest,
+    ) -> Result<Watchlist> {
+        self.put(&format!("/v2/watchlists/{}", watchlist_id), watchlist)
+            .await
+    }
+
+    /// Delete watchlist
+    pub async fn delete_watchlist(&self, watchlist_id: &Uuid) -> Result<()> {
+        self.delete(&format!("/v2/watchlists/{}", watchlist_id))
+            .await
+    }
+
+    /// Add asset to watchlist
+    pub async fn add_to_watchlist(&self, watchlist_id: &Uuid, symbol: &str) -> Result<Watchlist> {
+        let request = AddToWatchlistRequest {
+            symbol: symbol.to_string(),
+        };
+        self.post(&format!("/v2/watchlists/{}", watchlist_id), &request)
+            .await
+    }
+
+    /// Remove asset from watchlist
+    pub async fn remove_from_watchlist(&self, watchlist_id: &Uuid, symbol: &str) -> Result<()> {
+        self.delete(&format!("/v2/watchlists/{}/{}", watchlist_id, symbol))
+            .await
+    }
+
+    // Market data endpoints
+
+    /// Get bars for a symbol
+    pub async fn get_bars(&self, symbol: &str, params: &BarsParams) -> Result<BarsResponse> {
+        self.get_with_params(&format!("/v2/stocks/{}/bars", symbol), params)
+            .await
+    }
+
+    /// Get quotes for a symbol
+    pub async fn get_quotes(&self, symbol: &str, params: &QuotesParams) -> Result<QuotesResponse> {
+        self.get_with_params(&format!("/v2/stocks/{}/quotes", symbol), params)
+            .await
+    }
+
+    /// Get trades for a symbol
+    pub async fn get_trades(&self, symbol: &str, params: &TradesParams) -> Result<TradesResponse> {
+        self.get_with_params(&format!("/v2/stocks/{}/trades", symbol), params)
+            .await
+    }
+
+    /// Get latest bar for a symbol
+    pub async fn get_latest_bar(&self, symbol: &str) -> Result<LatestBarResponse> {
+        self.get(&format!("/v2/stocks/{}/bars/latest", symbol))
+            .await
+    }
+
+    /// Get latest quote for a symbol
+    pub async fn get_latest_quote(&self, symbol: &str) -> Result<LatestQuoteResponse> {
+        self.get(&format!("/v2/stocks/{}/quotes/latest", symbol))
+            .await
+    }
+
+    /// Get latest trade for a symbol
+    pub async fn get_latest_trade(&self, symbol: &str) -> Result<LatestTradeResponse> {
+        self.get(&format!("/v2/stocks/{}/trades/latest", symbol))
+            .await
+    }
+
+    // Calendar and clock endpoints
+
+    /// Get market calendar
+    pub async fn get_calendar(&self, params: &CalendarParams) -> Result<Vec<Calendar>> {
+        self.get_with_params("/v2/calendar", params).await
+    }
+
+    /// Get market clock
+    pub async fn get_clock(&self) -> Result<Clock> {
+        self.get("/v2/clock").await
+    }
+
+    // News endpoints
+
+    /// Get news articles
+    pub async fn get_news(&self, params: &NewsParams) -> Result<NewsResponse> {
+        self.get_with_params("/v1beta1/news", params).await
+    }
+
+    // Crypto endpoints
+
+    /// Get crypto bars
+    pub async fn get_crypto_bars(
+        &self,
+        symbol: &str,
+        params: &CryptoBarsParams,
+    ) -> Result<CryptoBarsResponse> {
+        self.get_with_params(&format!("/v1beta1/crypto/{}/bars", symbol), params)
+            .await
+    }
+
+    /// Get crypto quotes
+    pub async fn get_crypto_quotes(
+        &self,
+        symbol: &str,
+        params: &CryptoQuotesParams,
+    ) -> Result<CryptoQuotesResponse> {
+        self.get_with_params(&format!("/v1beta1/crypto/{}/quotes", symbol), params)
+            .await
+    }
+
+    /// Get crypto trades
+    pub async fn get_crypto_trades(
+        &self,
+        symbol: &str,
+        params: &CryptoTradesParams,
+    ) -> Result<CryptoTradesResponse> {
+        self.get_with_params(&format!("/v1beta1/crypto/{}/trades", symbol), params)
+            .await
+    }
+}
+
+// Request/Response types
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AccountConfigurations {
+    pub dtbp_check: Option<String>,
+    pub trade_confirm_email: Option<String>,
+    pub suspend_trade: Option<bool>,
+    pub no_shorting: Option<bool>,
+    pub max_margin_multiplier: Option<String>,
+    pub pdt_check: Option<String>,
+    pub max_dte: Option<i32>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ActivityParams {
+    pub activity_type: Option<ActivityType>,
+    pub date: Option<String>,
+    pub until: Option<String>,
+    pub after: Option<String>,
+    pub direction: Option<String>,
+    pub page_size: Option<u32>,
+    pub page_token: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PortfolioHistoryParams {
+    pub period: Option<String>,
+    pub timeframe: Option<String>,
+    pub date_end: Option<String>,
+    pub extended_hours: Option<bool>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AssetParams {
+    pub status: Option<AssetStatus>,
+    pub asset_class: Option<AssetClass>,
+    pub exchange: Option<String>,
+    pub attributes: Option<String>,
+}
+
+/// Parameters for querying orders.
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct OrderParams {
+    /// Filter by order status (open, closed, all).
+    pub status: Option<OrderQueryStatus>,
+    /// Maximum number of orders to return (default 50, max 500).
+    pub limit: Option<u32>,
+    /// Filter orders created after this timestamp.
+    pub after: Option<DateTime<Utc>>,
+    /// Filter orders created until this timestamp.
+    pub until: Option<DateTime<Utc>>,
+    /// Sort direction (asc or desc).
+    pub direction: Option<SortDirection>,
+    /// Include nested leg orders for multi-leg orders.
+    pub nested: Option<bool>,
+    /// Comma-separated list of symbols to filter by.
+    pub symbols: Option<String>,
+    /// Filter by order side (buy or sell).
+    pub side: Option<OrderSide>,
+}
+
+impl OrderParams {
+    /// Creates a new empty OrderParams.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the status filter.
+    #[must_use]
+    pub fn status(mut self, status: OrderQueryStatus) -> Self {
+        self.status = Some(status);
+        self
+    }
+
+    /// Sets the limit.
+    #[must_use]
+    pub fn limit(mut self, limit: u32) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+
+    /// Sets the after timestamp filter.
+    #[must_use]
+    pub fn after(mut self, after: DateTime<Utc>) -> Self {
+        self.after = Some(after);
+        self
+    }
+
+    /// Sets the until timestamp filter.
+    #[must_use]
+    pub fn until(mut self, until: DateTime<Utc>) -> Self {
+        self.until = Some(until);
+        self
+    }
+
+    /// Sets the sort direction.
+    #[must_use]
+    pub fn direction(mut self, direction: SortDirection) -> Self {
+        self.direction = Some(direction);
+        self
+    }
+
+    /// Enables nested leg orders in response.
+    #[must_use]
+    pub fn nested(mut self, nested: bool) -> Self {
+        self.nested = Some(nested);
+        self
+    }
+
+    /// Sets the symbols filter.
+    #[must_use]
+    pub fn symbols(mut self, symbols: impl Into<String>) -> Self {
+        self.symbols = Some(symbols.into());
+        self
+    }
+
+    /// Sets the side filter.
+    #[must_use]
+    pub fn side(mut self, side: OrderSide) -> Self {
+        self.side = Some(side);
+        self
+    }
+}
+
+/// Request to create a new order.
+///
+/// Supports all order types including simple, bracket, OCO, and OTO orders.
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct CreateOrderRequest {
+    /// The symbol to trade.
+    pub symbol: String,
+    /// The quantity to trade (mutually exclusive with notional).
+    pub qty: Option<String>,
+    /// The notional dollar amount to trade (mutually exclusive with qty).
+    pub notional: Option<String>,
+    /// The side of the order (buy or sell).
+    pub side: OrderSide,
+    /// The type of order.
+    #[serde(rename = "type")]
+    pub order_type: OrderType,
+    /// How long the order remains active.
+    pub time_in_force: TimeInForce,
+    /// Limit price for limit orders.
+    pub limit_price: Option<String>,
+    /// Stop price for stop orders.
+    pub stop_price: Option<String>,
+    /// Trail price for trailing stop orders (dollar amount).
+    pub trail_price: Option<String>,
+    /// Trail percent for trailing stop orders (percentage).
+    pub trail_percent: Option<String>,
+    /// Whether to allow trading during extended hours.
+    pub extended_hours: Option<bool>,
+    /// Client-specified order ID for idempotency.
+    pub client_order_id: Option<String>,
+    /// Order class (simple, bracket, oco, oto).
+    pub order_class: Option<OrderClass>,
+    /// Take profit configuration for bracket orders.
+    pub take_profit: Option<TakeProfit>,
+    /// Stop loss configuration for bracket orders.
+    pub stop_loss: Option<StopLoss>,
+    /// Position intent for options orders.
+    pub position_intent: Option<PositionIntent>,
+    /// Good-till-date expiration (for GTD orders).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gtd_date: Option<NaiveDate>,
+}
+
+impl CreateOrderRequest {
+    /// Creates a new market order request.
+    #[must_use]
+    pub fn market(symbol: impl Into<String>, side: OrderSide, qty: impl Into<String>) -> Self {
+        Self {
+            symbol: symbol.into(),
+            qty: Some(qty.into()),
+            side,
+            order_type: OrderType::Market,
+            time_in_force: TimeInForce::Day,
+            ..Default::default()
+        }
+    }
+
+    /// Creates a new limit order request.
+    #[must_use]
+    pub fn limit(
+        symbol: impl Into<String>,
+        side: OrderSide,
+        qty: impl Into<String>,
+        limit_price: impl Into<String>,
+    ) -> Self {
+        Self {
+            symbol: symbol.into(),
+            qty: Some(qty.into()),
+            side,
+            order_type: OrderType::Limit,
+            time_in_force: TimeInForce::Day,
+            limit_price: Some(limit_price.into()),
+            ..Default::default()
+        }
+    }
+
+    /// Creates a new stop order request.
+    #[must_use]
+    pub fn stop(
+        symbol: impl Into<String>,
+        side: OrderSide,
+        qty: impl Into<String>,
+        stop_price: impl Into<String>,
+    ) -> Self {
+        Self {
+            symbol: symbol.into(),
+            qty: Some(qty.into()),
+            side,
+            order_type: OrderType::Stop,
+            time_in_force: TimeInForce::Day,
+            stop_price: Some(stop_price.into()),
+            ..Default::default()
+        }
+    }
+
+    /// Creates a new stop-limit order request.
+    #[must_use]
+    pub fn stop_limit(
+        symbol: impl Into<String>,
+        side: OrderSide,
+        qty: impl Into<String>,
+        stop_price: impl Into<String>,
+        limit_price: impl Into<String>,
+    ) -> Self {
+        Self {
+            symbol: symbol.into(),
+            qty: Some(qty.into()),
+            side,
+            order_type: OrderType::StopLimit,
+            time_in_force: TimeInForce::Day,
+            stop_price: Some(stop_price.into()),
+            limit_price: Some(limit_price.into()),
+            ..Default::default()
+        }
+    }
+
+    /// Creates a new trailing stop order request with a trail price.
+    #[must_use]
+    pub fn trailing_stop_price(
+        symbol: impl Into<String>,
+        side: OrderSide,
+        qty: impl Into<String>,
+        trail_price: impl Into<String>,
+    ) -> Self {
+        Self {
+            symbol: symbol.into(),
+            qty: Some(qty.into()),
+            side,
+            order_type: OrderType::TrailingStop,
+            time_in_force: TimeInForce::Day,
+            trail_price: Some(trail_price.into()),
+            ..Default::default()
+        }
+    }
+
+    /// Creates a new trailing stop order request with a trail percent.
+    #[must_use]
+    pub fn trailing_stop_percent(
+        symbol: impl Into<String>,
+        side: OrderSide,
+        qty: impl Into<String>,
+        trail_percent: impl Into<String>,
+    ) -> Self {
+        Self {
+            symbol: symbol.into(),
+            qty: Some(qty.into()),
+            side,
+            order_type: OrderType::TrailingStop,
+            time_in_force: TimeInForce::Day,
+            trail_percent: Some(trail_percent.into()),
+            ..Default::default()
+        }
+    }
+
+    /// Creates a new bracket order request.
+    ///
+    /// A bracket order is a set of three orders: a primary order and two
+    /// conditional orders (take profit and stop loss) that are triggered
+    /// when the primary order fills.
+    #[must_use]
+    pub fn bracket(
+        symbol: impl Into<String>,
+        side: OrderSide,
+        qty: impl Into<String>,
+        order_type: OrderType,
+        take_profit: TakeProfit,
+        stop_loss: StopLoss,
+    ) -> Self {
+        Self {
+            symbol: symbol.into(),
+            qty: Some(qty.into()),
+            side,
+            order_type,
+            time_in_force: TimeInForce::Day,
+            order_class: Some(OrderClass::Bracket),
+            take_profit: Some(take_profit),
+            stop_loss: Some(stop_loss),
+            ..Default::default()
+        }
+    }
+
+    /// Creates a new OCO (One-Cancels-Other) order request.
+    ///
+    /// An OCO order is a set of two orders where if one is executed,
+    /// the other is automatically canceled.
+    #[must_use]
+    pub fn oco(
+        symbol: impl Into<String>,
+        side: OrderSide,
+        qty: impl Into<String>,
+        take_profit: TakeProfit,
+        stop_loss: StopLoss,
+    ) -> Self {
+        Self {
+            symbol: symbol.into(),
+            qty: Some(qty.into()),
+            side,
+            order_type: OrderType::Limit,
+            time_in_force: TimeInForce::Day,
+            order_class: Some(OrderClass::Oco),
+            take_profit: Some(take_profit),
+            stop_loss: Some(stop_loss),
+            ..Default::default()
+        }
+    }
+
+    /// Creates a new OTO (One-Triggers-Other) order request.
+    ///
+    /// An OTO order is a primary order that, when filled, triggers
+    /// a secondary order.
+    #[must_use]
+    pub fn oto(
+        symbol: impl Into<String>,
+        side: OrderSide,
+        qty: impl Into<String>,
+        order_type: OrderType,
+        stop_loss: StopLoss,
+    ) -> Self {
+        Self {
+            symbol: symbol.into(),
+            qty: Some(qty.into()),
+            side,
+            order_type,
+            time_in_force: TimeInForce::Day,
+            order_class: Some(OrderClass::Oto),
+            stop_loss: Some(stop_loss),
+            ..Default::default()
+        }
+    }
+
+    /// Sets the time in force for the order.
+    #[must_use]
+    pub fn time_in_force(mut self, tif: TimeInForce) -> Self {
+        self.time_in_force = tif;
+        self
+    }
+
+    /// Sets the limit price for the order.
+    #[must_use]
+    pub fn with_limit_price(mut self, price: impl Into<String>) -> Self {
+        self.limit_price = Some(price.into());
+        self
+    }
+
+    /// Enables extended hours trading.
+    #[must_use]
+    pub fn extended_hours(mut self, enabled: bool) -> Self {
+        self.extended_hours = Some(enabled);
+        self
+    }
+
+    /// Sets a client order ID for idempotency.
+    #[must_use]
+    pub fn client_order_id(mut self, id: impl Into<String>) -> Self {
+        self.client_order_id = Some(id.into());
+        self
+    }
+
+    /// Sets the position intent for options orders.
+    #[must_use]
+    pub fn position_intent(mut self, intent: PositionIntent) -> Self {
+        self.position_intent = Some(intent);
+        self
+    }
+
+    /// Sets the GTD (Good Till Date) expiration date.
+    #[must_use]
+    pub fn gtd_date(mut self, date: NaiveDate) -> Self {
+        self.time_in_force = TimeInForce::Gtd;
+        self.gtd_date = Some(date);
+        self
+    }
+}
+
+/// Request to replace (modify) an existing order.
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct ReplaceOrderRequest {
+    /// New quantity for the order.
+    pub qty: Option<String>,
+    /// New time in force.
+    pub time_in_force: Option<TimeInForce>,
+    /// New limit price.
+    pub limit_price: Option<String>,
+    /// New stop price.
+    pub stop_price: Option<String>,
+    /// New trail value (price or percent depending on original order).
+    pub trail: Option<String>,
+    /// New client order ID.
+    pub client_order_id: Option<String>,
+}
+
+impl ReplaceOrderRequest {
+    /// Creates a new empty replace order request.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the new quantity.
+    #[must_use]
+    pub fn qty(mut self, qty: impl Into<String>) -> Self {
+        self.qty = Some(qty.into());
+        self
+    }
+
+    /// Sets the new time in force.
+    #[must_use]
+    pub fn time_in_force(mut self, tif: TimeInForce) -> Self {
+        self.time_in_force = Some(tif);
+        self
+    }
+
+    /// Sets the new limit price.
+    #[must_use]
+    pub fn limit_price(mut self, price: impl Into<String>) -> Self {
+        self.limit_price = Some(price.into());
+        self
+    }
+
+    /// Sets the new stop price.
+    #[must_use]
+    pub fn stop_price(mut self, price: impl Into<String>) -> Self {
+        self.stop_price = Some(price.into());
+        self
+    }
+
+    /// Sets the new trail value.
+    #[must_use]
+    pub fn trail(mut self, trail: impl Into<String>) -> Self {
+        self.trail = Some(trail.into());
+        self
+    }
+
+    /// Sets the new client order ID.
+    #[must_use]
+    pub fn client_order_id(mut self, id: impl Into<String>) -> Self {
+        self.client_order_id = Some(id.into());
+        self
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CancelOrderResponse {
+    pub id: Uuid,
+    pub status: i32,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ClosePositionResponse {
+    pub symbol: String,
+    pub status: i32,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ClosePositionRequest {
+    pub qty: Option<String>,
+    pub percentage: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CreateWatchlistRequest {
+    pub name: String,
+    pub symbols: Option<Vec<String>>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UpdateWatchlistRequest {
+    pub name: Option<String>,
+    pub symbols: Option<Vec<String>>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AddToWatchlistRequest {
+    pub symbol: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BarsParams {
+    pub start: Option<DateTime<Utc>>,
+    pub end: Option<DateTime<Utc>>,
+    pub timeframe: Option<String>,
+    pub page_token: Option<String>,
+    pub limit: Option<u32>,
+    pub asof: Option<String>,
+    pub feed: Option<String>,
+    pub sort: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BarsResponse {
+    pub bars: Vec<Bar>,
+    pub symbol: String,
+    pub next_page_token: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct QuotesParams {
+    pub start: Option<DateTime<Utc>>,
+    pub end: Option<DateTime<Utc>>,
+    pub page_token: Option<String>,
+    pub limit: Option<u32>,
+    pub asof: Option<String>,
+    pub feed: Option<String>,
+    pub sort: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct QuotesResponse {
+    pub quotes: Vec<Quote>,
+    pub symbol: String,
+    pub next_page_token: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TradesParams {
+    pub start: Option<DateTime<Utc>>,
+    pub end: Option<DateTime<Utc>>,
+    pub page_token: Option<String>,
+    pub limit: Option<u32>,
+    pub asof: Option<String>,
+    pub feed: Option<String>,
+    pub sort: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TradesResponse {
+    pub trades: Vec<Trade>,
+    pub symbol: String,
+    pub next_page_token: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LatestBarResponse {
+    pub bar: Bar,
+    pub symbol: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LatestQuoteResponse {
+    pub quote: Quote,
+    pub symbol: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LatestTradeResponse {
+    pub trade: Trade,
+    pub symbol: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CalendarParams {
+    pub start: Option<String>,
+    pub end: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NewsParams {
+    pub symbols: Option<String>,
+    pub start: Option<DateTime<Utc>>,
+    pub end: Option<DateTime<Utc>>,
+    pub sort: Option<String>,
+    pub include_content: Option<bool>,
+    pub exclude_contentless: Option<bool>,
+    pub page_token: Option<String>,
+    pub limit: Option<u32>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NewsResponse {
+    pub news: Vec<NewsArticle>,
+    pub next_page_token: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CryptoBarsParams {
+    pub start: Option<DateTime<Utc>>,
+    pub end: Option<DateTime<Utc>>,
+    pub timeframe: Option<String>,
+    pub page_token: Option<String>,
+    pub limit: Option<u32>,
+    pub sort: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CryptoBarsResponse {
+    pub bars: Vec<Bar>,
+    pub symbol: String,
+    pub next_page_token: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CryptoQuotesParams {
+    pub start: Option<DateTime<Utc>>,
+    pub end: Option<DateTime<Utc>>,
+    pub page_token: Option<String>,
+    pub limit: Option<u32>,
+    pub sort: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CryptoQuotesResponse {
+    pub quotes: Vec<Quote>,
+    pub symbol: String,
+    pub next_page_token: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CryptoTradesParams {
+    pub start: Option<DateTime<Utc>>,
+    pub end: Option<DateTime<Utc>>,
+    pub page_token: Option<String>,
+    pub limit: Option<u32>,
+    pub sort: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CryptoTradesResponse {
+    pub trades: Vec<Trade>,
+    pub symbol: String,
+    pub next_page_token: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_order_request_market() {
+        let order = CreateOrderRequest::market("AAPL", OrderSide::Buy, "10");
+        assert_eq!(order.symbol, "AAPL");
+        assert_eq!(order.side, OrderSide::Buy);
+        assert_eq!(order.qty, Some("10".to_string()));
+        assert_eq!(order.order_type, OrderType::Market);
+        assert_eq!(order.time_in_force, TimeInForce::Day);
+    }
+
+    #[test]
+    fn test_create_order_request_limit() {
+        let order = CreateOrderRequest::limit("AAPL", OrderSide::Buy, "10", "150.00");
+        assert_eq!(order.symbol, "AAPL");
+        assert_eq!(order.limit_price, Some("150.00".to_string()));
+        assert_eq!(order.order_type, OrderType::Limit);
+    }
+
+    #[test]
+    fn test_create_order_request_stop() {
+        let order = CreateOrderRequest::stop("AAPL", OrderSide::Sell, "10", "145.00");
+        assert_eq!(order.stop_price, Some("145.00".to_string()));
+        assert_eq!(order.order_type, OrderType::Stop);
+    }
+
+    #[test]
+    fn test_create_order_request_stop_limit() {
+        let order =
+            CreateOrderRequest::stop_limit("AAPL", OrderSide::Sell, "10", "145.00", "144.50");
+        assert_eq!(order.stop_price, Some("145.00".to_string()));
+        assert_eq!(order.limit_price, Some("144.50".to_string()));
+        assert_eq!(order.order_type, OrderType::StopLimit);
+    }
+
+    #[test]
+    fn test_create_order_request_trailing_stop_price() {
+        let order = CreateOrderRequest::trailing_stop_price("AAPL", OrderSide::Sell, "10", "5.00");
+        assert_eq!(order.trail_price, Some("5.00".to_string()));
+        assert_eq!(order.order_type, OrderType::TrailingStop);
+    }
+
+    #[test]
+    fn test_create_order_request_trailing_stop_percent() {
+        let order = CreateOrderRequest::trailing_stop_percent("AAPL", OrderSide::Sell, "10", "2.5");
+        assert_eq!(order.trail_percent, Some("2.5".to_string()));
+        assert_eq!(order.order_type, OrderType::TrailingStop);
+    }
+
+    #[test]
+    fn test_create_order_request_bracket() {
+        let tp = TakeProfit::new("160.00");
+        let sl = StopLoss::new("140.00");
+        let order =
+            CreateOrderRequest::bracket("AAPL", OrderSide::Buy, "10", OrderType::Market, tp, sl);
+
+        assert_eq!(order.order_class, Some(OrderClass::Bracket));
+        assert!(order.take_profit.is_some());
+        assert!(order.stop_loss.is_some());
+        assert_eq!(order.take_profit.unwrap().limit_price, "160.00");
+        assert_eq!(order.stop_loss.unwrap().stop_price, "140.00");
+    }
+
+    #[test]
+    fn test_create_order_request_oco() {
+        let tp = TakeProfit::new("160.00");
+        let sl = StopLoss::with_limit("140.00", "139.50");
+        let order = CreateOrderRequest::oco("AAPL", OrderSide::Sell, "10", tp, sl);
+
+        assert_eq!(order.order_class, Some(OrderClass::Oco));
+        assert!(order.take_profit.is_some());
+        assert!(order.stop_loss.is_some());
+    }
+
+    #[test]
+    fn test_create_order_request_oto() {
+        let sl = StopLoss::new("140.00");
+        let order = CreateOrderRequest::oto("AAPL", OrderSide::Buy, "10", OrderType::Limit, sl);
+
+        assert_eq!(order.order_class, Some(OrderClass::Oto));
+        assert!(order.stop_loss.is_some());
+    }
+
+    #[test]
+    fn test_create_order_request_builder_methods() {
+        let order = CreateOrderRequest::market("AAPL", OrderSide::Buy, "10")
+            .time_in_force(TimeInForce::Gtc)
+            .extended_hours(true)
+            .client_order_id("my-order-123");
+
+        assert_eq!(order.time_in_force, TimeInForce::Gtc);
+        assert_eq!(order.extended_hours, Some(true));
+        assert_eq!(order.client_order_id, Some("my-order-123".to_string()));
+    }
+
+    #[test]
+    fn test_create_order_request_position_intent() {
+        let order = CreateOrderRequest::market("AAPL", OrderSide::Buy, "10")
+            .position_intent(PositionIntent::BuyToOpen);
+
+        assert_eq!(order.position_intent, Some(PositionIntent::BuyToOpen));
+    }
+
+    #[test]
+    fn test_replace_order_request_builder() {
+        let request = ReplaceOrderRequest::new()
+            .qty("20")
+            .limit_price("155.00")
+            .time_in_force(TimeInForce::Gtc);
+
+        assert_eq!(request.qty, Some("20".to_string()));
+        assert_eq!(request.limit_price, Some("155.00".to_string()));
+        assert_eq!(request.time_in_force, Some(TimeInForce::Gtc));
+    }
+
+    #[test]
+    fn test_order_params_builder() {
+        let params = OrderParams::new()
+            .status(OrderQueryStatus::Open)
+            .limit(100)
+            .nested(true)
+            .symbols("AAPL,GOOGL")
+            .side(OrderSide::Buy)
+            .direction(SortDirection::Desc);
+
+        assert_eq!(params.status, Some(OrderQueryStatus::Open));
+        assert_eq!(params.limit, Some(100));
+        assert_eq!(params.nested, Some(true));
+        assert_eq!(params.symbols, Some("AAPL,GOOGL".to_string()));
+        assert_eq!(params.side, Some(OrderSide::Buy));
+        assert_eq!(params.direction, Some(SortDirection::Desc));
+    }
+
+    #[test]
+    fn test_create_order_request_serialization() {
+        let order = CreateOrderRequest::limit("AAPL", OrderSide::Buy, "10", "150.00")
+            .client_order_id("test-123");
+
+        let json = serde_json::to_string(&order).unwrap();
+        assert!(json.contains("\"symbol\":\"AAPL\""));
+        assert!(json.contains("\"side\":\"buy\""));
+        assert!(json.contains("\"type\":\"limit\""));
+        assert!(json.contains("\"limit_price\":\"150.00\""));
+    }
+
+    #[test]
+    fn test_bracket_order_serialization() {
+        let tp = TakeProfit::new("160.00");
+        let sl = StopLoss::with_limit("140.00", "139.50");
+        let order =
+            CreateOrderRequest::bracket("AAPL", OrderSide::Buy, "10", OrderType::Limit, tp, sl)
+                .with_limit_price("150.00");
+
+        let json = serde_json::to_string(&order).unwrap();
+        assert!(json.contains("\"order_class\":\"bracket\""));
+        assert!(json.contains("\"take_profit\""));
+        assert!(json.contains("\"stop_loss\""));
+    }
+}

--- a/alpaca-http/src/error.rs
+++ b/alpaca-http/src/error.rs
@@ -1,0 +1,30 @@
+use alpaca_base::AlpacaError;
+use thiserror::Error;
+
+/// HTTP-specific errors for the Alpaca client
+#[derive(Error, Debug)]
+pub enum HttpError {
+    /// Wrapped base Alpaca error
+    #[error(transparent)]
+    Base(#[from] AlpacaError),
+
+    /// HTTP client errors
+    #[error("HTTP client error: {0}")]
+    Client(#[from] reqwest::Error),
+
+    /// URL parsing errors
+    #[error("URL parsing error: {0}")]
+    Url(#[from] url::ParseError),
+
+    /// Request timeout
+    #[error("Request timeout")]
+    Timeout,
+
+    /// Too many requests (rate limited)
+    #[error("Rate limited: {0}")]
+    RateLimited(String),
+
+    /// Server error
+    #[error("Server error: {status} - {message}")]
+    Server { status: u16, message: String },
+}

--- a/alpaca-http/src/lib.rs
+++ b/alpaca-http/src/lib.rs
@@ -1,0 +1,12 @@
+//! # Alpaca HTTP Client
+//!
+//! HTTP REST API client for Alpaca trading platform.
+//! This crate provides a comprehensive client for interacting with Alpaca's REST API endpoints.
+
+pub mod client;
+pub mod endpoints;
+pub mod error;
+
+pub use alpaca_base::*;
+pub use client::AlpacaHttpClient;
+pub use error::HttpError;

--- a/alpaca-websocket/Cargo.toml
+++ b/alpaca-websocket/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "alpaca-websocket"
+version = "0.1.0"
+edition = "2024"
+authors = ["Joaquin Bejar <jb@taunais.com>"]
+description = "WebSocket client for Alpaca trading platform real-time data"
+license = "MIT"
+readme = "README.md"
+repository = "https://github.com/joaquinbejar/alpaca-rs"
+homepage = "https://github.com/joaquinbejar/alpaca-rs"
+keywords = ["finance", "alpaca", "trading", "websocket", "realtime"]
+categories = ["finance", "api-bindings", "web-programming::websocket"]
+
+[features]
+default = []
+integration-tests = []
+
+[dependencies]
+alpaca-base = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tracing = { workspace = true }
+tokio-tungstenite = { workspace = true }
+tokio = { workspace = true }
+futures-util = { workspace = true }
+url = { workspace = true }
+chrono = { workspace = true }
+uuid = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+dotenvy = { workspace = true }

--- a/alpaca-websocket/src/client.rs
+++ b/alpaca-websocket/src/client.rs
@@ -1,0 +1,335 @@
+use crate::{messages::*, streams::*};
+use alpaca_base::{AlpacaError, Result, auth::Credentials, types::Environment};
+use futures_util::{
+    sink::SinkExt,
+    stream::{SplitSink, SplitStream, StreamExt},
+};
+use serde_json;
+use std::time::Duration;
+use tokio::{
+    net::TcpStream,
+    sync::mpsc,
+    time::{interval, sleep},
+};
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, connect_async, tungstenite::Message};
+use tracing::{debug, error, info, warn};
+
+type WsStream = WebSocketStream<MaybeTlsStream<TcpStream>>;
+type WsSink = SplitSink<WsStream, Message>;
+type WsReceiver = SplitStream<WsStream>;
+
+/// WebSocket client for Alpaca API
+#[derive(Debug)]
+pub struct AlpacaWebSocketClient {
+    credentials: Credentials,
+    environment: Environment,
+    url: String,
+}
+
+impl AlpacaWebSocketClient {
+    /// Create a new WebSocket client
+    pub fn new(credentials: Credentials, environment: Environment) -> Self {
+        let url = match environment {
+            Environment::Paper => "wss://stream.data.alpaca.markets/v2/iex",
+            Environment::Live => "wss://stream.data.alpaca.markets/v2/sip",
+        };
+
+        Self {
+            credentials,
+            environment,
+            url: url.to_string(),
+        }
+    }
+
+    /// Create a new client from environment variables
+    pub fn from_env(environment: Environment) -> Result<Self> {
+        let credentials = Credentials::from_env()?;
+        Ok(Self::new(credentials, environment))
+    }
+
+    /// Create a trading WebSocket client
+    pub fn trading(credentials: Credentials, environment: Environment) -> Self {
+        let url = environment.websocket_url();
+        Self {
+            credentials,
+            environment,
+            url: url.to_string(),
+        }
+    }
+
+    /// Connect to the WebSocket and return a stream of messages
+    pub async fn connect(&self) -> Result<AlpacaStream> {
+        let (sender, receiver) = mpsc::unbounded_channel();
+        info!("Connecting to WebSocket: {}", self.url);
+        let (ws_stream, _) = connect_async(&self.url).await?;
+        let (mut sink, mut stream) = ws_stream.split();
+
+        // Authenticate
+        self.authenticate(&mut sink).await?;
+
+        // Spawn message handler
+        let credentials = self.credentials.clone();
+        tokio::spawn(async move {
+            Self::handle_messages(&mut stream, sender, credentials).await;
+        });
+
+        Ok(AlpacaStream::new(receiver))
+    }
+
+    /// Connect with automatic reconnection
+    pub async fn connect_with_reconnect(&self, max_retries: u32) -> Result<AlpacaStream> {
+        let mut attempts = 0;
+        let mut delay = Duration::from_secs(1);
+
+        loop {
+            match self.connect().await {
+                Ok(stream) => {
+                    info!("Successfully connected to WebSocket");
+                    return Ok(stream);
+                }
+                Err(e) => {
+                    attempts += 1;
+                    if attempts >= max_retries {
+                        error!("Failed to connect after {} attempts", attempts);
+                        return Err(AlpacaError::WebSocket(format!(
+                            "Connection failed after {} attempts: {}",
+                            attempts, e
+                        )));
+                    }
+
+                    warn!(
+                        "Connection attempt {} failed: {}. Retrying in {:?}",
+                        attempts, e, delay
+                    );
+                    sleep(delay).await;
+                    delay = std::cmp::min(delay * 2, Duration::from_secs(60));
+                }
+            }
+        }
+    }
+
+    /// Subscribe to market data
+    pub async fn subscribe_market_data(
+        &self,
+        _subscription: SubscribeMessage,
+    ) -> Result<MarketDataStream> {
+        let stream = self.connect().await?;
+        let (sender, receiver) = mpsc::unbounded_channel();
+
+        // Send subscription
+        // Note: In a real implementation, you'd need to send the subscription message
+        // through the WebSocket connection. This is simplified for the example.
+
+        tokio::spawn(async move {
+            let mut market_data_stream = stream.market_data();
+            while let Some(update) = market_data_stream.next().await {
+                if sender.send(update).is_err() {
+                    break;
+                }
+            }
+        });
+
+        Ok(MarketDataStream::new(receiver))
+    }
+
+    /// Subscribe to trading updates
+    pub async fn subscribe_trading_updates(&self) -> Result<TradingStream> {
+        let stream = self.connect().await?;
+        let (sender, receiver) = mpsc::unbounded_channel();
+
+        tokio::spawn(async move {
+            let mut trading_stream = stream.trading_updates();
+            while let Some(update) = trading_stream.next().await {
+                if sender.send(update).is_err() {
+                    break;
+                }
+            }
+        });
+
+        Ok(TradingStream::new(receiver))
+    }
+
+    /// Authenticate with the WebSocket
+    async fn authenticate(&self, sink: &mut WsSink) -> Result<()> {
+        let auth_msg = WebSocketMessage::Auth(AuthMessage {
+            key: self.credentials.api_key.clone(),
+            secret: self.credentials.secret_key.clone(),
+        });
+
+        let auth_json = serde_json::to_string(&auth_msg)?;
+        sink.send(Message::Text(auth_json.into())).await?;
+
+        debug!("Sent authentication message");
+        Ok(())
+    }
+
+    /// Handle incoming WebSocket messages
+    async fn handle_messages(
+        stream: &mut WsReceiver,
+        sender: mpsc::UnboundedSender<WebSocketMessage>,
+        _credentials: Credentials,
+    ) {
+        while let Some(message) = stream.next().await {
+            match message {
+                Ok(Message::Text(text)) => match Self::parse_message(&text) {
+                    Ok(msg) => {
+                        debug!("Received message: {:?}", msg);
+                        if sender.send(msg).is_err() {
+                            warn!("Failed to send message to channel");
+                            break;
+                        }
+                    }
+                    Err(e) => {
+                        warn!("Failed to parse message: {} - Raw: {}", e, text);
+                    }
+                },
+                Ok(Message::Close(_)) => {
+                    info!("WebSocket connection closed");
+                    break;
+                }
+                Ok(Message::Ping(_data)) => {
+                    debug!("Received ping, sending pong");
+                    // Note: tokio-tungstenite handles pong automatically
+                }
+                Ok(Message::Pong(_)) => {
+                    debug!("Received pong");
+                }
+                Ok(Message::Binary(_)) => {
+                    warn!("Received unexpected binary message");
+                }
+                Ok(Message::Frame(_)) => {
+                    debug!("Received frame message");
+                }
+                Err(e) => {
+                    error!("WebSocket error: {}", e);
+                    break;
+                }
+            }
+        }
+
+        info!("Message handler exiting");
+    }
+
+    /// Parse incoming WebSocket message
+    fn parse_message(text: &str) -> Result<WebSocketMessage> {
+        // Handle array of messages
+        if text.starts_with('[') {
+            let messages: Vec<serde_json::Value> = serde_json::from_str(text)?;
+            if let Some(first_msg) = messages.first() {
+                return serde_json::from_value(first_msg.clone())
+                    .map_err(|e| AlpacaError::Json(e.to_string()));
+            }
+        }
+
+        // Handle single message
+        serde_json::from_str(text).map_err(|e| AlpacaError::Json(e.to_string()))
+    }
+
+    /// Send subscription message
+    pub async fn send_subscription(&self, subscription: SubscribeMessage) -> Result<()> {
+        // This would need to be implemented with a persistent connection
+        // For now, this is a placeholder
+        debug!("Would send subscription: {:?}", subscription);
+        Ok(())
+    }
+
+    /// Send unsubscription message
+    pub async fn send_unsubscription(&self, unsubscription: UnsubscribeMessage) -> Result<()> {
+        // This would need to be implemented with a persistent connection
+        // For now, this is a placeholder
+        debug!("Would send unsubscription: {:?}", unsubscription);
+        Ok(())
+    }
+
+    /// Get the WebSocket URL
+    pub fn url(&self) -> &str {
+        &self.url
+    }
+
+    /// Get the environment
+    pub fn environment(&self) -> &Environment {
+        &self.environment
+    }
+}
+
+/// WebSocket connection manager with automatic reconnection
+pub struct WebSocketManager {
+    client: AlpacaWebSocketClient,
+    max_retries: u32,
+    heartbeat_interval: Duration,
+}
+
+impl WebSocketManager {
+    /// Create a new WebSocket manager
+    pub fn new(client: AlpacaWebSocketClient) -> Self {
+        Self {
+            client,
+            max_retries: 5,
+            heartbeat_interval: Duration::from_secs(30),
+        }
+    }
+
+    /// Set maximum retry attempts
+    pub fn with_max_retries(mut self, max_retries: u32) -> Self {
+        self.max_retries = max_retries;
+        self
+    }
+
+    /// Set heartbeat interval
+    pub fn with_heartbeat_interval(mut self, interval: Duration) -> Self {
+        self.heartbeat_interval = interval;
+        self
+    }
+
+    /// Start the managed connection
+    pub async fn start(&self) -> Result<AlpacaStream> {
+        let stream = self.client.connect_with_reconnect(self.max_retries).await?;
+
+        // Start heartbeat
+        self.start_heartbeat().await;
+
+        Ok(stream)
+    }
+
+    /// Start heartbeat to keep connection alive
+    async fn start_heartbeat(&self) {
+        let mut interval = interval(self.heartbeat_interval);
+
+        tokio::spawn(async move {
+            loop {
+                interval.tick().await;
+                debug!("Heartbeat tick");
+                // In a real implementation, you might send a ping message here
+            }
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alpaca_base::types::Environment;
+
+    #[test]
+    fn test_client_creation() {
+        let credentials = Credentials::new("test_key".to_string(), "test_secret".to_string());
+        let client = AlpacaWebSocketClient::new(credentials, Environment::Paper);
+
+        assert!(client.url().contains("stream.data.alpaca.markets"));
+    }
+
+    #[test]
+    fn test_trading_client() {
+        let credentials = Credentials::new("test_key".to_string(), "test_secret".to_string());
+        let client = AlpacaWebSocketClient::trading(credentials, Environment::Paper);
+
+        assert!(client.url().contains("paper-api.alpaca.markets"));
+    }
+
+    #[test]
+    fn test_parse_message() {
+        let json = r#"{"T":"success","msg":"authenticated"}"#;
+        let result = AlpacaWebSocketClient::parse_message(json);
+        assert!(result.is_ok());
+    }
+}

--- a/alpaca-websocket/src/error.rs
+++ b/alpaca-websocket/src/error.rs
@@ -1,0 +1,42 @@
+use alpaca_base::AlpacaError;
+use thiserror::Error;
+
+/// WebSocket-specific errors for the Alpaca client
+#[derive(Error, Debug)]
+pub enum WebSocketError {
+    /// Wrapped base Alpaca error
+    #[error(transparent)]
+    Base(#[from] AlpacaError),
+
+    /// WebSocket connection errors
+    #[error("WebSocket connection error: {0}")]
+    Connection(#[from] tokio_tungstenite::tungstenite::Error),
+
+    /// URL parsing errors
+    #[error("URL parsing error: {0}")]
+    Url(#[from] url::ParseError),
+
+    /// Connection closed unexpectedly
+    #[error("Connection closed: {0}")]
+    ConnectionClosed(String),
+
+    /// Authentication failed
+    #[error("Authentication failed: {0}")]
+    AuthenticationFailed(String),
+
+    /// Subscription error
+    #[error("Subscription error: {0}")]
+    Subscription(String),
+
+    /// Message parsing error
+    #[error("Message parsing error: {0}")]
+    MessageParsing(String),
+
+    /// Channel send error
+    #[error("Channel send error")]
+    ChannelSend,
+
+    /// Reconnection failed
+    #[error("Reconnection failed after {attempts} attempts")]
+    ReconnectionFailed { attempts: u32 },
+}

--- a/alpaca-websocket/src/lib.rs
+++ b/alpaca-websocket/src/lib.rs
@@ -1,0 +1,15 @@
+//! # Alpaca WebSocket Client
+//!
+//! WebSocket client for Alpaca trading platform real-time data.
+//! This crate provides real-time market data and trading updates via WebSocket connections.
+
+pub mod client;
+pub mod error;
+pub mod messages;
+pub mod streams;
+
+pub use alpaca_base::*;
+pub use client::AlpacaWebSocketClient;
+pub use error::WebSocketError;
+pub use messages::*;
+pub use streams::*;

--- a/alpaca-websocket/src/messages.rs
+++ b/alpaca-websocket/src/messages.rs
@@ -1,0 +1,313 @@
+use alpaca_base::types::*;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// WebSocket message types
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "T")]
+pub enum WebSocketMessage {
+    /// Authentication message
+    #[serde(rename = "auth")]
+    Auth(AuthMessage),
+
+    /// Subscription message
+    #[serde(rename = "subscribe")]
+    Subscribe(SubscribeMessage),
+
+    /// Unsubscription message
+    #[serde(rename = "unsubscribe")]
+    Unsubscribe(UnsubscribeMessage),
+
+    /// Market data messages
+    #[serde(rename = "t")]
+    Trade(TradeMessage),
+
+    #[serde(rename = "q")]
+    Quote(QuoteMessage),
+
+    #[serde(rename = "b")]
+    Bar(BarMessage),
+
+    /// Trading messages
+    #[serde(rename = "trade_updates")]
+    TradeUpdate(Box<TradeUpdateMessage>),
+
+    /// Status messages
+    #[serde(rename = "success")]
+    Success(SuccessMessage),
+
+    #[serde(rename = "error")]
+    Error(ErrorMessage),
+
+    /// Connection status
+    #[serde(rename = "connection")]
+    Connection(ConnectionMessage),
+}
+
+/// Authentication message
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuthMessage {
+    pub key: String,
+    pub secret: String,
+}
+
+/// Subscription message
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SubscribeMessage {
+    pub trades: Option<Vec<String>>,
+    pub quotes: Option<Vec<String>>,
+    pub bars: Option<Vec<String>>,
+    pub trade_updates: Option<bool>,
+}
+
+/// Unsubscription message
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UnsubscribeMessage {
+    pub trades: Option<Vec<String>>,
+    pub quotes: Option<Vec<String>>,
+    pub bars: Option<Vec<String>>,
+    pub trade_updates: Option<bool>,
+}
+
+/// Trade message from WebSocket
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TradeMessage {
+    #[serde(rename = "S")]
+    pub symbol: String,
+    #[serde(rename = "t")]
+    pub timestamp: DateTime<Utc>,
+    #[serde(rename = "p")]
+    pub price: f64,
+    #[serde(rename = "s")]
+    pub size: u32,
+    #[serde(rename = "x")]
+    pub exchange: String,
+    #[serde(rename = "c")]
+    pub conditions: Vec<String>,
+    #[serde(rename = "i")]
+    pub id: u64,
+}
+
+/// Quote message from WebSocket
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QuoteMessage {
+    #[serde(rename = "S")]
+    pub symbol: String,
+    #[serde(rename = "t")]
+    pub timestamp: DateTime<Utc>,
+    #[serde(rename = "bp")]
+    pub bid_price: f64,
+    #[serde(rename = "bs")]
+    pub bid_size: u32,
+    #[serde(rename = "ap")]
+    pub ask_price: f64,
+    #[serde(rename = "as")]
+    pub ask_size: u32,
+    #[serde(rename = "bx")]
+    pub bid_exchange: String,
+    #[serde(rename = "ax")]
+    pub ask_exchange: String,
+}
+
+/// Bar message from WebSocket
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BarMessage {
+    #[serde(rename = "S")]
+    pub symbol: String,
+    #[serde(rename = "t")]
+    pub timestamp: DateTime<Utc>,
+    #[serde(rename = "o")]
+    pub open: f64,
+    #[serde(rename = "h")]
+    pub high: f64,
+    #[serde(rename = "l")]
+    pub low: f64,
+    #[serde(rename = "c")]
+    pub close: f64,
+    #[serde(rename = "v")]
+    pub volume: u64,
+    #[serde(rename = "n")]
+    pub trade_count: Option<u64>,
+    #[serde(rename = "vw")]
+    pub vwap: Option<f64>,
+}
+
+/// Trade update message
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TradeUpdateMessage {
+    pub event: TradeUpdateEvent,
+    pub order: Order,
+    pub timestamp: DateTime<Utc>,
+    pub position_qty: Option<String>,
+    pub price: Option<String>,
+    pub qty: Option<String>,
+}
+
+/// Trade update event types
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TradeUpdateEvent {
+    New,
+    Fill,
+    PartialFill,
+    Canceled,
+    Expired,
+    DoneForDay,
+    Replaced,
+    Rejected,
+    PendingNew,
+    Stopped,
+    PendingCancel,
+    PendingReplace,
+    Calculated,
+    Suspended,
+    OrderReplacePending,
+    OrderCancelPending,
+}
+
+/// Success message
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SuccessMessage {
+    pub msg: String,
+}
+
+/// Error message
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ErrorMessage {
+    pub code: u16,
+    pub msg: String,
+}
+
+/// Connection status message
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConnectionMessage {
+    pub status: ConnectionStatus,
+}
+
+/// Connection status
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConnectionStatus {
+    Connected,
+    Authenticated,
+    AuthenticationFailed,
+    Disconnected,
+    Reconnecting,
+}
+
+/// Subscription request builder
+#[derive(Debug, Default)]
+pub struct SubscriptionBuilder {
+    trades: Vec<String>,
+    quotes: Vec<String>,
+    bars: Vec<String>,
+    trade_updates: bool,
+}
+
+impl SubscriptionBuilder {
+    /// Create a new subscription builder
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Subscribe to trades for symbols
+    pub fn trades<I, S>(mut self, symbols: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.trades.extend(symbols.into_iter().map(|s| s.into()));
+        self
+    }
+
+    /// Subscribe to quotes for symbols
+    pub fn quotes<I, S>(mut self, symbols: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.quotes.extend(symbols.into_iter().map(|s| s.into()));
+        self
+    }
+
+    /// Subscribe to bars for symbols
+    pub fn bars<I, S>(mut self, symbols: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.bars.extend(symbols.into_iter().map(|s| s.into()));
+        self
+    }
+
+    /// Subscribe to trade updates
+    pub fn trade_updates(mut self) -> Self {
+        self.trade_updates = true;
+        self
+    }
+
+    /// Build the subscription message
+    pub fn build(self) -> SubscribeMessage {
+        SubscribeMessage {
+            trades: if self.trades.is_empty() {
+                None
+            } else {
+                Some(self.trades)
+            },
+            quotes: if self.quotes.is_empty() {
+                None
+            } else {
+                Some(self.quotes)
+            },
+            bars: if self.bars.is_empty() {
+                None
+            } else {
+                Some(self.bars)
+            },
+            trade_updates: if self.trade_updates { Some(true) } else { None },
+        }
+    }
+}
+
+impl From<TradeMessage> for Trade {
+    fn from(msg: TradeMessage) -> Self {
+        Trade {
+            timestamp: msg.timestamp,
+            price: msg.price,
+            size: msg.size,
+            exchange: msg.exchange,
+            conditions: msg.conditions,
+            id: msg.id,
+        }
+    }
+}
+
+impl From<QuoteMessage> for Quote {
+    fn from(msg: QuoteMessage) -> Self {
+        Quote {
+            timestamp: msg.timestamp,
+            timeframe: "real-time".to_string(),
+            bid_price: msg.bid_price,
+            bid_size: msg.bid_size,
+            ask_price: msg.ask_price,
+            ask_size: msg.ask_size,
+            bid_exchange: msg.bid_exchange,
+            ask_exchange: msg.ask_exchange,
+        }
+    }
+}
+
+impl From<BarMessage> for Bar {
+    fn from(msg: BarMessage) -> Self {
+        Bar {
+            timestamp: msg.timestamp,
+            open: msg.open,
+            high: msg.high,
+            low: msg.low,
+            close: msg.close,
+            volume: msg.volume,
+            trade_count: msg.trade_count,
+            vwap: msg.vwap,
+        }
+    }
+}

--- a/alpaca-websocket/src/streams.rs
+++ b/alpaca-websocket/src/streams.rs
@@ -1,0 +1,144 @@
+use crate::messages::*;
+use alpaca_base::types::*;
+use futures_util::stream::Stream;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio::sync::mpsc;
+
+/// Stream of market data updates
+pub struct MarketDataStream {
+    receiver: mpsc::UnboundedReceiver<MarketDataUpdate>,
+}
+
+/// Market data update enum
+#[derive(Debug, Clone)]
+pub enum MarketDataUpdate {
+    Trade { symbol: String, trade: Trade },
+    Quote { symbol: String, quote: Quote },
+    Bar { symbol: String, bar: Bar },
+}
+
+impl MarketDataStream {
+    /// Create a new market data stream
+    pub fn new(receiver: mpsc::UnboundedReceiver<MarketDataUpdate>) -> Self {
+        Self { receiver }
+    }
+}
+
+impl Stream for MarketDataStream {
+    type Item = MarketDataUpdate;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.receiver.poll_recv(cx)
+    }
+}
+
+/// Stream of trading updates
+pub struct TradingStream {
+    receiver: mpsc::UnboundedReceiver<TradeUpdateMessage>,
+}
+
+impl TradingStream {
+    /// Create a new trading stream
+    pub fn new(receiver: mpsc::UnboundedReceiver<TradeUpdateMessage>) -> Self {
+        Self { receiver }
+    }
+}
+
+impl Stream for TradingStream {
+    type Item = TradeUpdateMessage;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.receiver.poll_recv(cx)
+    }
+}
+
+/// Stream of connection status updates
+pub struct StatusStream {
+    receiver: mpsc::UnboundedReceiver<ConnectionStatus>,
+}
+
+impl StatusStream {
+    /// Create a new status stream
+    pub fn new(receiver: mpsc::UnboundedReceiver<ConnectionStatus>) -> Self {
+        Self { receiver }
+    }
+}
+
+impl Stream for StatusStream {
+    type Item = ConnectionStatus;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.receiver.poll_recv(cx)
+    }
+}
+
+/// Combined stream of all WebSocket messages
+pub struct AlpacaStream {
+    receiver: mpsc::UnboundedReceiver<WebSocketMessage>,
+}
+
+impl AlpacaStream {
+    /// Create a new Alpaca stream
+    pub fn new(receiver: mpsc::UnboundedReceiver<WebSocketMessage>) -> Self {
+        Self { receiver }
+    }
+
+    /// Filter for market data updates only
+    pub fn market_data(self) -> impl Stream<Item = MarketDataUpdate> + Unpin {
+        Box::pin(futures_util::stream::StreamExt::filter_map(
+            self,
+            |msg| async move {
+                match msg {
+                    WebSocketMessage::Trade(trade_msg) => Some(MarketDataUpdate::Trade {
+                        symbol: trade_msg.symbol.clone(),
+                        trade: trade_msg.into(),
+                    }),
+                    WebSocketMessage::Quote(quote_msg) => Some(MarketDataUpdate::Quote {
+                        symbol: quote_msg.symbol.clone(),
+                        quote: quote_msg.into(),
+                    }),
+                    WebSocketMessage::Bar(bar_msg) => Some(MarketDataUpdate::Bar {
+                        symbol: bar_msg.symbol.clone(),
+                        bar: bar_msg.into(),
+                    }),
+                    _ => None,
+                }
+            },
+        ))
+    }
+
+    /// Filter for trading updates only
+    pub fn trading_updates(self) -> impl Stream<Item = TradeUpdateMessage> + Unpin {
+        Box::pin(futures_util::stream::StreamExt::filter_map(
+            self,
+            |msg| async move {
+                match msg {
+                    WebSocketMessage::TradeUpdate(update) => Some(*update),
+                    _ => None,
+                }
+            },
+        ))
+    }
+
+    /// Filter for status updates only
+    pub fn status_updates(self) -> impl Stream<Item = ConnectionStatus> + Unpin {
+        Box::pin(futures_util::stream::StreamExt::filter_map(
+            self,
+            |msg| async move {
+                match msg {
+                    WebSocketMessage::Connection(conn) => Some(conn.status),
+                    _ => None,
+                }
+            },
+        ))
+    }
+}
+
+impl Stream for AlpacaStream {
+    type Item = WebSocketMessage;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.receiver.poll_recv(cx)
+    }
+}

--- a/examples/trading_bracket_order.rs
+++ b/examples/trading_bracket_order.rs
@@ -1,0 +1,154 @@
+//! Example: Creating Bracket Orders with Alpaca API
+//!
+//! This example demonstrates how to create bracket orders using the alpaca-http crate.
+//! A bracket order consists of a primary order with attached take-profit and stop-loss legs.
+//!
+//! ## Required Environment Variables
+//!
+//! Create a `.env` file in the project root with:
+//! ```env
+//! ALPACA_API_KEY=your_api_key
+//! ALPACA_API_SECRET=your_api_secret
+//! ALPACA_BASE_URL=https://paper-api.alpaca.markets
+//! ```
+//!
+//! ## Running the Example
+//!
+//! ```bash
+//! cargo run --example trading_bracket_order
+//! ```
+
+use alpaca_http::{AlpacaHttpClient, CreateOrderRequest, OrderParams};
+use alpaca_base::{OrderSide, OrderType, OrderQueryStatus, TakeProfit, StopLoss, Environment, Credentials};
+use std::env;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Load environment variables from .env file
+    dotenvy::dotenv().ok();
+
+    let api_key = env::var("ALPACA_API_KEY")
+        .expect("ALPACA_API_KEY must be set in .env file");
+    let api_secret = env::var("ALPACA_API_SECRET")
+        .expect("ALPACA_API_SECRET must be set in .env file");
+    let base_url = env::var("ALPACA_BASE_URL")
+        .unwrap_or_else(|_| "https://paper-api.alpaca.markets".to_string());
+
+    println!("Connecting to Alpaca API at: {}", base_url);
+
+    // Determine environment from URL
+    let environment = if base_url.contains("paper") {
+        Environment::Paper
+    } else {
+        Environment::Live
+    };
+
+    // Create credentials and HTTP client
+    let credentials = Credentials::new(api_key, api_secret);
+    let client = AlpacaHttpClient::new(credentials, environment)?;
+
+    // Get account information
+    let account = client.get_account().await?;
+    println!("Account ID: {}", account.id);
+    println!("Buying Power: ${}", account.buying_power);
+    println!("Portfolio Value: ${}", account.portfolio_value);
+
+    // Example 1: Create a bracket order
+    // This creates a buy order with automatic take-profit and stop-loss legs
+    println!("\n--- Creating Bracket Order ---");
+    
+    let take_profit = TakeProfit::new("160.00");
+    let stop_loss = StopLoss::with_limit("140.00", "139.50");
+    
+    let bracket_order = CreateOrderRequest::bracket(
+        "AAPL",
+        OrderSide::Buy,
+        "1",
+        OrderType::Limit,
+        take_profit,
+        stop_loss,
+    )
+    .with_limit_price("150.00")
+    .client_order_id("bracket-example-001");
+
+    println!("Bracket order request: {:?}", bracket_order);
+    
+    // Uncomment to actually submit the order:
+    // let order = client.create_order(&bracket_order).await?;
+    // println!("Created bracket order: {:?}", order);
+
+    // Example 2: Create different order types
+    println!("\n--- Order Type Examples ---");
+
+    // Market order
+    let market_order = CreateOrderRequest::market("AAPL", OrderSide::Buy, "1")
+        .client_order_id("market-example-001");
+    println!("Market order: {:?}", market_order);
+
+    // Limit order
+    let limit_order = CreateOrderRequest::limit("AAPL", OrderSide::Buy, "1", "150.00")
+        .extended_hours(true)
+        .client_order_id("limit-example-001");
+    println!("Limit order: {:?}", limit_order);
+
+    // Stop order
+    let stop_order = CreateOrderRequest::stop("AAPL", OrderSide::Sell, "1", "145.00")
+        .client_order_id("stop-example-001");
+    println!("Stop order: {:?}", stop_order);
+
+    // Stop-limit order
+    let stop_limit_order = CreateOrderRequest::stop_limit(
+        "AAPL",
+        OrderSide::Sell,
+        "1",
+        "145.00",
+        "144.50",
+    )
+    .client_order_id("stop-limit-example-001");
+    println!("Stop-limit order: {:?}", stop_limit_order);
+
+    // Trailing stop order (by price)
+    let trailing_stop_price = CreateOrderRequest::trailing_stop_price(
+        "AAPL",
+        OrderSide::Sell,
+        "1",
+        "5.00",
+    )
+    .client_order_id("trailing-price-example-001");
+    println!("Trailing stop (price): {:?}", trailing_stop_price);
+
+    // Trailing stop order (by percent)
+    let trailing_stop_percent = CreateOrderRequest::trailing_stop_percent(
+        "AAPL",
+        OrderSide::Sell,
+        "1",
+        "2.5",
+    )
+    .client_order_id("trailing-percent-example-001");
+    println!("Trailing stop (percent): {:?}", trailing_stop_percent);
+
+    // Example 3: Query existing orders
+    println!("\n--- Querying Orders ---");
+    
+    let order_params = OrderParams::new()
+        .status(OrderQueryStatus::All)
+        .limit(10)
+        .nested(true);
+    
+    let orders = client.get_orders(&order_params).await?;
+    println!("Found {} orders", orders.len());
+    
+    for order in orders.iter().take(5) {
+        println!(
+            "  - {} {} {} @ {:?} ({})",
+            order.side,
+            order.qty.as_deref().unwrap_or("N/A"),
+            order.symbol,
+            order.limit_price,
+            order.status
+        );
+    }
+
+    println!("\nExample completed successfully!");
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Implements Issue #012 - Advanced Order Types and Features. This PR adds comprehensive support for advanced order types including bracket orders, OCO, OTO, and enhanced order management with builder patterns.

## Changes

### New Types (alpaca-base)
- `PositionIntent` enum for options orders (buy_to_open, buy_to_close, sell_to_open, sell_to_close)
- `TakeProfit` struct with helper constructor
- `StopLoss` struct with `new()` and `with_limit()` constructors
- `SortDirection` enum (Asc, Desc)
- `OrderQueryStatus` enum (Open, Closed, All)
- Added `Gtd` (Good Till Date) to `TimeInForce` enum
- Added `Default` implementations for `OrderSide`, `OrderType`, `TimeInForce`

### Enhanced Order Creation (alpaca-http)
- Builder pattern for `CreateOrderRequest` with factory methods:
  - `market()`, `limit()`, `stop()`, `stop_limit()`
  - `trailing_stop_price()`, `trailing_stop_percent()`
  - `bracket()`, `oco()`, `oto()`
- Builder pattern for `ReplaceOrderRequest`
- Builder pattern for `OrderParams` with new `side` filter

### Examples
- Added `examples/trading_bracket_order.rs` demonstrating all order types
- Added `.env.example` for configuration

## Testing

- Unit tests: 36 tests covering all new types and builders
- All tests pass: `make test`
- Linting passes: `make lint-fix`

## Checklist

- [x] Version bumped (alpaca-base: 0.2.0, alpaca-http: 0.2.0)
- [x] README updated with usage examples
- [x] Unit tests added (36 total)
- [x] Examples created in `examples/`
- [x] `make lint-fix` passes

Closes #012