### PR TITLE
feat(market-data): implement Enhanced Stock Market Data API

### DIFF
--- a/alpaca-base/Cargo.toml
+++ b/alpaca-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alpaca-base"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "Base library with common structs, traits, and logic for Alpaca API clients"

--- a/alpaca-base/src/types.rs
+++ b/alpaca-base/src/types.rs
@@ -1000,6 +1000,397 @@ impl OptionBarsParams {
     }
 }
 
+// ============================================================================
+// Enhanced Stock Market Data Types
+// ============================================================================
+
+/// Data feed source.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum DataFeed {
+    /// IEX exchange data.
+    Iex,
+    /// SIP (Securities Information Processor) data.
+    Sip,
+    /// OTC (Over-The-Counter) data.
+    Otc,
+}
+
+/// Stock snapshot with latest market data.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct StockSnapshot {
+    /// Latest trade.
+    #[serde(rename = "latestTrade")]
+    pub latest_trade: Option<Trade>,
+    /// Latest quote.
+    #[serde(rename = "latestQuote")]
+    pub latest_quote: Option<Quote>,
+    /// Current minute bar.
+    #[serde(rename = "minuteBar")]
+    pub minute_bar: Option<Bar>,
+    /// Current daily bar.
+    #[serde(rename = "dailyBar")]
+    pub daily_bar: Option<Bar>,
+    /// Previous daily bar.
+    #[serde(rename = "prevDailyBar")]
+    pub prev_daily_bar: Option<Bar>,
+}
+
+/// Corporate action type.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CorporateActionType {
+    /// Cash dividend.
+    Dividend,
+    /// Stock split.
+    Split,
+    /// Reverse stock split.
+    ReverseSplit,
+    /// Spinoff.
+    Spinoff,
+    /// Merger.
+    Merger,
+    /// Rights issue.
+    Rights,
+    /// Stock distribution.
+    StockDividend,
+    /// Redemption.
+    Redemption,
+    /// Name change.
+    NameChange,
+    /// Symbol change.
+    SymbolChange,
+    /// Worthless security.
+    Worthless,
+}
+
+/// Corporate action announcement.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CorporateAction {
+    /// Unique identifier.
+    pub id: String,
+    /// Corporate action type.
+    #[serde(rename = "ca_type")]
+    pub action_type: CorporateActionType,
+    /// Sub-type of the action.
+    #[serde(rename = "ca_sub_type")]
+    pub sub_type: Option<String>,
+    /// Initiating symbol.
+    pub initiating_symbol: Option<String>,
+    /// Initiating original CUSIP.
+    pub initiating_original_cusip: Option<String>,
+    /// Target symbol.
+    pub target_symbol: Option<String>,
+    /// Target original CUSIP.
+    pub target_original_cusip: Option<String>,
+    /// Declaration date.
+    pub declaration_date: Option<String>,
+    /// Ex-date.
+    pub ex_date: Option<String>,
+    /// Record date.
+    pub record_date: Option<String>,
+    /// Payable date.
+    pub payable_date: Option<String>,
+    /// Cash amount per share.
+    pub cash: Option<String>,
+    /// Old rate (for splits).
+    pub old_rate: Option<String>,
+    /// New rate (for splits).
+    pub new_rate: Option<String>,
+}
+
+/// Limit Up Limit Down (LULD) data.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Luld {
+    /// LULD indicator.
+    #[serde(rename = "i")]
+    pub indicator: String,
+    /// Limit up price.
+    #[serde(rename = "u")]
+    pub limit_up_price: f64,
+    /// Limit down price.
+    #[serde(rename = "d")]
+    pub limit_down_price: f64,
+    /// Timestamp.
+    #[serde(rename = "t")]
+    pub timestamp: DateTime<Utc>,
+}
+
+/// Trading status update.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct TradingStatus {
+    /// Status code.
+    #[serde(rename = "sc")]
+    pub status_code: String,
+    /// Status message.
+    #[serde(rename = "sm")]
+    pub status_message: String,
+    /// Reason code.
+    #[serde(rename = "rc")]
+    pub reason_code: String,
+    /// Reason message.
+    #[serde(rename = "rm")]
+    pub reason_message: String,
+    /// Timestamp.
+    #[serde(rename = "t")]
+    pub timestamp: DateTime<Utc>,
+}
+
+/// Auction data.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Auction {
+    /// Auction type (open, close).
+    #[serde(rename = "at")]
+    pub auction_type: String,
+    /// Auction price.
+    #[serde(rename = "ap")]
+    pub price: Option<f64>,
+    /// Auction size.
+    #[serde(rename = "as")]
+    pub size: Option<u64>,
+    /// Timestamp.
+    #[serde(rename = "t")]
+    pub timestamp: DateTime<Utc>,
+}
+
+/// Parameters for multi-symbol bars request.
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+pub struct MultiBarsParams {
+    /// Comma-separated list of symbols.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub symbols: Option<String>,
+    /// Timeframe (e.g., "1Min", "1Hour", "1Day").
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timeframe: Option<String>,
+    /// Start time (RFC3339).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start: Option<String>,
+    /// End time (RFC3339).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub end: Option<String>,
+    /// Maximum number of bars per symbol.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u32>,
+    /// Data feed source.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub feed: Option<DataFeed>,
+    /// Pagination token.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub page_token: Option<String>,
+}
+
+impl MultiBarsParams {
+    /// Create new parameters with symbols.
+    #[must_use]
+    pub fn new(symbols: &str) -> Self {
+        Self {
+            symbols: Some(symbols.to_string()),
+            ..Default::default()
+        }
+    }
+
+    /// Set timeframe.
+    #[must_use]
+    pub fn timeframe(mut self, timeframe: &str) -> Self {
+        self.timeframe = Some(timeframe.to_string());
+        self
+    }
+
+    /// Set time range.
+    #[must_use]
+    pub fn time_range(mut self, start: &str, end: &str) -> Self {
+        self.start = Some(start.to_string());
+        self.end = Some(end.to_string());
+        self
+    }
+
+    /// Set data feed.
+    #[must_use]
+    pub fn feed(mut self, feed: DataFeed) -> Self {
+        self.feed = Some(feed);
+        self
+    }
+
+    /// Set limit.
+    #[must_use]
+    pub fn limit(mut self, limit: u32) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+}
+
+/// Parameters for multi-symbol quotes request.
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+pub struct MultiQuotesParams {
+    /// Comma-separated list of symbols.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub symbols: Option<String>,
+    /// Start time (RFC3339).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start: Option<String>,
+    /// End time (RFC3339).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub end: Option<String>,
+    /// Maximum number of quotes per symbol.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u32>,
+    /// Data feed source.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub feed: Option<DataFeed>,
+    /// Pagination token.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub page_token: Option<String>,
+}
+
+impl MultiQuotesParams {
+    /// Create new parameters with symbols.
+    #[must_use]
+    pub fn new(symbols: &str) -> Self {
+        Self {
+            symbols: Some(symbols.to_string()),
+            ..Default::default()
+        }
+    }
+
+    /// Set time range.
+    #[must_use]
+    pub fn time_range(mut self, start: &str, end: &str) -> Self {
+        self.start = Some(start.to_string());
+        self.end = Some(end.to_string());
+        self
+    }
+
+    /// Set data feed.
+    #[must_use]
+    pub fn feed(mut self, feed: DataFeed) -> Self {
+        self.feed = Some(feed);
+        self
+    }
+
+    /// Set limit.
+    #[must_use]
+    pub fn limit(mut self, limit: u32) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+}
+
+/// Parameters for multi-symbol trades request.
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+pub struct MultiTradesParams {
+    /// Comma-separated list of symbols.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub symbols: Option<String>,
+    /// Start time (RFC3339).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start: Option<String>,
+    /// End time (RFC3339).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub end: Option<String>,
+    /// Maximum number of trades per symbol.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u32>,
+    /// Data feed source.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub feed: Option<DataFeed>,
+    /// Pagination token.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub page_token: Option<String>,
+}
+
+impl MultiTradesParams {
+    /// Create new parameters with symbols.
+    #[must_use]
+    pub fn new(symbols: &str) -> Self {
+        Self {
+            symbols: Some(symbols.to_string()),
+            ..Default::default()
+        }
+    }
+
+    /// Set time range.
+    #[must_use]
+    pub fn time_range(mut self, start: &str, end: &str) -> Self {
+        self.start = Some(start.to_string());
+        self.end = Some(end.to_string());
+        self
+    }
+
+    /// Set data feed.
+    #[must_use]
+    pub fn feed(mut self, feed: DataFeed) -> Self {
+        self.feed = Some(feed);
+        self
+    }
+
+    /// Set limit.
+    #[must_use]
+    pub fn limit(mut self, limit: u32) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+}
+
+/// Parameters for corporate actions request.
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+pub struct CorporateActionsParams {
+    /// Filter by symbols.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub symbols: Option<String>,
+    /// Filter by action types.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub types: Option<String>,
+    /// Start date (YYYY-MM-DD).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start: Option<String>,
+    /// End date (YYYY-MM-DD).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub end: Option<String>,
+    /// Maximum number of results.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u32>,
+    /// Pagination token.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub page_token: Option<String>,
+}
+
+impl CorporateActionsParams {
+    /// Create new empty parameters.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Filter by symbols.
+    #[must_use]
+    pub fn symbols(mut self, symbols: &str) -> Self {
+        self.symbols = Some(symbols.to_string());
+        self
+    }
+
+    /// Filter by action types.
+    #[must_use]
+    pub fn types(mut self, types: &str) -> Self {
+        self.types = Some(types.to_string());
+        self
+    }
+
+    /// Set date range.
+    #[must_use]
+    pub fn date_range(mut self, start: &str, end: &str) -> Self {
+        self.start = Some(start.to_string());
+        self.end = Some(end.to_string());
+        self
+    }
+
+    /// Set limit.
+    #[must_use]
+    pub fn limit(mut self, limit: u32) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1180,5 +1571,55 @@ mod tests {
         assert_eq!(params.start, Some("2024-01-01".to_string()));
         assert_eq!(params.end, Some("2024-03-01".to_string()));
         assert_eq!(params.limit, Some(100));
+    }
+
+    #[test]
+    fn test_data_feed_serialization() {
+        let feed = DataFeed::Sip;
+        let json = serde_json::to_string(&feed).unwrap();
+        assert_eq!(json, "\"sip\"");
+
+        let feed = DataFeed::Iex;
+        let json = serde_json::to_string(&feed).unwrap();
+        assert_eq!(json, "\"iex\"");
+    }
+
+    #[test]
+    fn test_corporate_action_type_serialization() {
+        let action = CorporateActionType::Dividend;
+        let json = serde_json::to_string(&action).unwrap();
+        assert_eq!(json, "\"dividend\"");
+
+        let action = CorporateActionType::Split;
+        let json = serde_json::to_string(&action).unwrap();
+        assert_eq!(json, "\"split\"");
+    }
+
+    #[test]
+    fn test_multi_bars_params_builder() {
+        let params = MultiBarsParams::new("AAPL,MSFT,GOOGL")
+            .timeframe("1Day")
+            .time_range("2024-01-01", "2024-03-01")
+            .feed(DataFeed::Sip)
+            .limit(100);
+
+        assert_eq!(params.symbols, Some("AAPL,MSFT,GOOGL".to_string()));
+        assert_eq!(params.timeframe, Some("1Day".to_string()));
+        assert_eq!(params.feed, Some(DataFeed::Sip));
+        assert_eq!(params.limit, Some(100));
+    }
+
+    #[test]
+    fn test_corporate_actions_params_builder() {
+        let params = CorporateActionsParams::new()
+            .symbols("AAPL,MSFT")
+            .types("dividend,split")
+            .date_range("2024-01-01", "2024-12-31")
+            .limit(50);
+
+        assert_eq!(params.symbols, Some("AAPL,MSFT".to_string()));
+        assert_eq!(params.types, Some("dividend,split".to_string()));
+        assert_eq!(params.start, Some("2024-01-01".to_string()));
+        assert_eq!(params.limit, Some(50));
     }
 }

--- a/alpaca-http/Cargo.toml
+++ b/alpaca-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alpaca-http"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "HTTP REST API client for Alpaca trading platform"

--- a/alpaca-http/examples/market_data.rs
+++ b/alpaca-http/examples/market_data.rs
@@ -1,0 +1,133 @@
+//! Enhanced Stock Market Data Example
+//!
+//! This example demonstrates how to use the enhanced stock market data API
+//! including multi-symbol queries, snapshots, and corporate actions.
+//!
+//! # Prerequisites
+//! - Alpaca account with market data access
+//! - API credentials in `.env` file
+//!
+//! # Environment Variables
+//! - `ALPACA_API_KEY`: Your Alpaca API key
+//! - `ALPACA_API_SECRET`: Your Alpaca API secret
+//!
+//! # Usage
+//! ```bash
+//! cargo run -p alpaca-http --example market_data
+//! ```
+
+use alpaca_base::{CorporateActionsParams, Credentials, DataFeed, Environment, MultiBarsParams};
+use alpaca_http::AlpacaHttpClient;
+use dotenvy::dotenv;
+use std::env;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Load environment variables from .env file
+    dotenv().ok();
+
+    // Get credentials from environment
+    let api_key = env::var("ALPACA_API_KEY").expect("ALPACA_API_KEY must be set");
+    let api_secret = env::var("ALPACA_API_SECRET").expect("ALPACA_API_SECRET must be set");
+
+    // Create credentials and client
+    let credentials = Credentials::new(api_key, api_secret);
+    let client = AlpacaHttpClient::new(credentials, Environment::Paper)?;
+
+    println!("=== Enhanced Stock Market Data Example ===\n");
+
+    // Example 1: Get multi-symbol bars
+    println!("--- Multi-Symbol Historical Bars ---");
+
+    let params = MultiBarsParams::new("AAPL,MSFT,GOOGL")
+        .timeframe("1Day")
+        .feed(DataFeed::Iex)
+        .limit(5);
+
+    match client.get_stock_bars(&params).await {
+        Ok(response) => {
+            for (symbol, bars) in &response.bars {
+                println!("{}:", symbol);
+                for bar in bars.iter().take(3) {
+                    println!(
+                        "  {} - O:{:.2} H:{:.2} L:{:.2} C:{:.2} V:{}",
+                        bar.timestamp, bar.open, bar.high, bar.low, bar.close, bar.volume
+                    );
+                }
+            }
+        }
+        Err(e) => println!("Error fetching bars: {}", e),
+    }
+    println!();
+
+    // Example 2: Get stock snapshots
+    println!("--- Stock Snapshots ---");
+
+    match client.get_stock_snapshots("AAPL,MSFT").await {
+        Ok(response) => {
+            for (symbol, snapshot) in &response.snapshots {
+                println!("{}:", symbol);
+                if let Some(trade) = &snapshot.latest_trade {
+                    println!("  Latest Trade: ${:.2} x {}", trade.price, trade.size);
+                }
+                if let Some(quote) = &snapshot.latest_quote {
+                    println!(
+                        "  Latest Quote: Bid ${:.2} x {} / Ask ${:.2} x {}",
+                        quote.bid_price, quote.bid_size, quote.ask_price, quote.ask_size
+                    );
+                }
+                if let Some(bar) = &snapshot.daily_bar {
+                    println!(
+                        "  Daily Bar: O:{:.2} H:{:.2} L:{:.2} C:{:.2}",
+                        bar.open, bar.high, bar.low, bar.close
+                    );
+                }
+            }
+        }
+        Err(e) => println!("Error fetching snapshots: {}", e),
+    }
+    println!();
+
+    // Example 3: Get latest quotes
+    println!("--- Latest Quotes ---");
+
+    match client.get_latest_quotes("AAPL,MSFT,GOOGL").await {
+        Ok(response) => {
+            for (symbol, quote) in &response.quotes {
+                println!(
+                    "{}: Bid ${:.2} x {} / Ask ${:.2} x {}",
+                    symbol, quote.bid_price, quote.bid_size, quote.ask_price, quote.ask_size
+                );
+            }
+        }
+        Err(e) => println!("Error fetching latest quotes: {}", e),
+    }
+    println!();
+
+    // Example 4: Get corporate actions
+    println!("--- Corporate Actions ---");
+
+    let params = CorporateActionsParams::new()
+        .symbols("AAPL")
+        .types("dividend")
+        .limit(5);
+
+    match client.get_corporate_actions(&params).await {
+        Ok(response) => {
+            println!(
+                "Found {} corporate actions",
+                response.corporate_actions.len()
+            );
+            for action in response.corporate_actions.iter().take(5) {
+                println!(
+                    "  {:?} - Ex-date: {:?}, Cash: {:?}",
+                    action.action_type, action.ex_date, action.cash
+                );
+            }
+        }
+        Err(e) => println!("Error fetching corporate actions: {}", e),
+    }
+
+    println!("\n=== Example completed ===");
+    Ok(())
+}

--- a/alpaca-http/src/endpoints.rs
+++ b/alpaca-http/src/endpoints.rs
@@ -1049,6 +1049,207 @@ impl AlpacaHttpClient {
     }
 }
 
+// ============================================================================
+// Enhanced Stock Market Data Endpoints
+// ============================================================================
+
+/// Response for multi-symbol bars.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct MultiBarsResponse {
+    /// Map of symbol to bars.
+    pub bars: std::collections::HashMap<String, Vec<Bar>>,
+    /// Token for next page of results.
+    pub next_page_token: Option<String>,
+}
+
+/// Response for multi-symbol quotes.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct MultiQuotesResponse {
+    /// Map of symbol to quotes.
+    pub quotes: std::collections::HashMap<String, Vec<Quote>>,
+    /// Token for next page of results.
+    pub next_page_token: Option<String>,
+}
+
+/// Response for multi-symbol trades.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct MultiTradesResponse {
+    /// Map of symbol to trades.
+    pub trades: std::collections::HashMap<String, Vec<Trade>>,
+    /// Token for next page of results.
+    pub next_page_token: Option<String>,
+}
+
+/// Response for stock snapshots.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct StockSnapshotsResponse {
+    /// Map of symbol to snapshot.
+    #[serde(flatten)]
+    pub snapshots: std::collections::HashMap<String, StockSnapshot>,
+}
+
+/// Response for corporate actions.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CorporateActionsResponse {
+    /// List of corporate actions.
+    pub corporate_actions: Vec<CorporateAction>,
+    /// Token for next page of results.
+    pub next_page_token: Option<String>,
+}
+
+/// Response for latest bars.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LatestBarsResponse {
+    /// Map of symbol to latest bar.
+    pub bars: std::collections::HashMap<String, Bar>,
+}
+
+/// Response for latest quotes.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LatestQuotesResponse {
+    /// Map of symbol to latest quote.
+    pub quotes: std::collections::HashMap<String, Quote>,
+}
+
+/// Response for latest trades.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LatestTradesResponse {
+    /// Map of symbol to latest trade.
+    pub trades: std::collections::HashMap<String, Trade>,
+}
+
+impl AlpacaHttpClient {
+    // ========================================================================
+    // Multi-Symbol Market Data Endpoints
+    // ========================================================================
+
+    /// Get historical bars for multiple symbols.
+    ///
+    /// # Arguments
+    /// * `params` - Query parameters including symbols, timeframe, and date range
+    ///
+    /// # Returns
+    /// Historical bar data for all requested symbols
+    pub async fn get_stock_bars(&self, params: &MultiBarsParams) -> Result<MultiBarsResponse> {
+        self.get_with_params("/v2/stocks/bars", params).await
+    }
+
+    /// Get historical quotes for multiple symbols.
+    ///
+    /// # Arguments
+    /// * `params` - Query parameters including symbols and date range
+    ///
+    /// # Returns
+    /// Historical quote data for all requested symbols
+    pub async fn get_stock_quotes(
+        &self,
+        params: &MultiQuotesParams,
+    ) -> Result<MultiQuotesResponse> {
+        self.get_with_params("/v2/stocks/quotes", params).await
+    }
+
+    /// Get historical trades for multiple symbols.
+    ///
+    /// # Arguments
+    /// * `params` - Query parameters including symbols and date range
+    ///
+    /// # Returns
+    /// Historical trade data for all requested symbols
+    pub async fn get_stock_trades(
+        &self,
+        params: &MultiTradesParams,
+    ) -> Result<MultiTradesResponse> {
+        self.get_with_params("/v2/stocks/trades", params).await
+    }
+
+    /// Get snapshots for multiple symbols.
+    ///
+    /// # Arguments
+    /// * `symbols` - Comma-separated list of symbols
+    ///
+    /// # Returns
+    /// Current snapshots with latest trade, quote, and bars
+    pub async fn get_stock_snapshots(&self, symbols: &str) -> Result<StockSnapshotsResponse> {
+        #[derive(Serialize)]
+        struct Params<'a> {
+            symbols: &'a str,
+        }
+        self.get_with_params("/v2/stocks/snapshots", &Params { symbols })
+            .await
+    }
+
+    // ========================================================================
+    // Latest Market Data Endpoints
+    // ========================================================================
+
+    /// Get latest bars for multiple symbols.
+    ///
+    /// # Arguments
+    /// * `symbols` - Comma-separated list of symbols
+    ///
+    /// # Returns
+    /// Latest bar for each symbol
+    pub async fn get_latest_bars(&self, symbols: &str) -> Result<LatestBarsResponse> {
+        #[derive(Serialize)]
+        struct Params<'a> {
+            symbols: &'a str,
+        }
+        self.get_with_params("/v2/stocks/bars/latest", &Params { symbols })
+            .await
+    }
+
+    /// Get latest quotes for multiple symbols.
+    ///
+    /// # Arguments
+    /// * `symbols` - Comma-separated list of symbols
+    ///
+    /// # Returns
+    /// Latest quote for each symbol
+    pub async fn get_latest_quotes(&self, symbols: &str) -> Result<LatestQuotesResponse> {
+        #[derive(Serialize)]
+        struct Params<'a> {
+            symbols: &'a str,
+        }
+        self.get_with_params("/v2/stocks/quotes/latest", &Params { symbols })
+            .await
+    }
+
+    /// Get latest trades for multiple symbols.
+    ///
+    /// # Arguments
+    /// * `symbols` - Comma-separated list of symbols
+    ///
+    /// # Returns
+    /// Latest trade for each symbol
+    pub async fn get_latest_trades(&self, symbols: &str) -> Result<LatestTradesResponse> {
+        #[derive(Serialize)]
+        struct Params<'a> {
+            symbols: &'a str,
+        }
+        self.get_with_params("/v2/stocks/trades/latest", &Params { symbols })
+            .await
+    }
+
+    // ========================================================================
+    // Corporate Actions Endpoints
+    // ========================================================================
+
+    /// Get corporate action announcements.
+    ///
+    /// # Arguments
+    /// * `params` - Query parameters for filtering corporate actions
+    ///
+    /// # Returns
+    /// List of corporate action announcements
+    pub async fn get_corporate_actions(
+        &self,
+        params: &CorporateActionsParams,
+    ) -> Result<CorporateActionsResponse> {
+        self.get_with_params("/v1beta1/corporate-actions/announcements", params)
+            .await
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

Implements Issue #9 - Enhanced Stock Market Data API. This PR adds comprehensive support for multi-symbol market data queries, snapshots, and corporate actions.

## Changes

### Types (alpaca-base v0.6.0)
- `DataFeed` enum: Iex, Sip, Otc
- `StockSnapshot` struct with latest trade, quote, and bars
- `CorporateActionType` enum: Dividend, Split, Merger, Spinoff, etc.
- `CorporateAction` struct with full announcement details
- `Luld` struct for Limit Up Limit Down data
- `TradingStatus` struct for trading halt information
- `Auction` struct for auction data
- `MultiBarsParams`, `MultiQuotesParams`, `MultiTradesParams` with builders
- `CorporateActionsParams` with builder pattern

### HTTP Endpoints (alpaca-http v0.5.0)
- `get_stock_bars()` - Multi-symbol historical bars
- `get_stock_quotes()` - Multi-symbol historical quotes
- `get_stock_trades()` - Multi-symbol historical trades
- `get_stock_snapshots()` - Multi-symbol snapshots
- `get_latest_bars()` - Latest bars for multiple symbols
- `get_latest_quotes()` - Latest quotes for multiple symbols
- `get_latest_trades()` - Latest trades for multiple symbols
- `get_corporate_actions()` - Corporate action announcements

### Example
- `market_data.rs` demonstrating multi-symbol queries and snapshots

## Testing

- Unit tests: 62 tests (4 new for market data types)
- All tests pass: `make test`
- Linting passes: `make pre-push`

## Checklist

- [x] Version bumped (alpaca-base: 0.6.0, alpaca-http: 0.5.0)
- [x] Unit tests added (4 new tests)
- [x] Examples created in `examples/`
- [x] `make pre-push` passes

Closes #9