### PR TITLE
feat(websocket): implement Enhanced WebSocket Streaming

### DIFF
--- a/alpaca-websocket/Cargo.toml
+++ b/alpaca-websocket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alpaca-websocket"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "WebSocket client for Alpaca trading platform real-time data"

--- a/alpaca-websocket/src/config.rs
+++ b/alpaca-websocket/src/config.rs
@@ -1,0 +1,187 @@
+//! WebSocket configuration types.
+
+/// Configuration for WebSocket connections.
+#[derive(Debug, Clone)]
+pub struct WebSocketConfig {
+    /// Whether automatic reconnection is enabled.
+    pub reconnect_enabled: bool,
+    /// Maximum number of reconnection attempts.
+    pub reconnect_max_attempts: u32,
+    /// Base delay between reconnection attempts in milliseconds.
+    pub reconnect_base_delay_ms: u64,
+    /// Maximum delay between reconnection attempts in milliseconds.
+    pub reconnect_max_delay_ms: u64,
+    /// Interval for sending ping messages in milliseconds.
+    pub ping_interval_ms: u64,
+    /// Size of the message buffer.
+    pub message_buffer_size: usize,
+    /// Connection timeout in milliseconds.
+    pub connection_timeout_ms: u64,
+}
+
+impl Default for WebSocketConfig {
+    fn default() -> Self {
+        Self {
+            reconnect_enabled: true,
+            reconnect_max_attempts: 10,
+            reconnect_base_delay_ms: 1000,
+            reconnect_max_delay_ms: 60000,
+            ping_interval_ms: 30000,
+            message_buffer_size: 1000,
+            connection_timeout_ms: 10000,
+        }
+    }
+}
+
+impl WebSocketConfig {
+    /// Create a new configuration with default values.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Disable automatic reconnection.
+    #[must_use]
+    pub fn no_reconnect(mut self) -> Self {
+        self.reconnect_enabled = false;
+        self
+    }
+
+    /// Set maximum reconnection attempts.
+    #[must_use]
+    pub fn max_reconnect_attempts(mut self, attempts: u32) -> Self {
+        self.reconnect_max_attempts = attempts;
+        self
+    }
+
+    /// Set base delay for reconnection in milliseconds.
+    #[must_use]
+    pub fn reconnect_base_delay(mut self, delay_ms: u64) -> Self {
+        self.reconnect_base_delay_ms = delay_ms;
+        self
+    }
+
+    /// Set ping interval in milliseconds.
+    #[must_use]
+    pub fn ping_interval(mut self, interval_ms: u64) -> Self {
+        self.ping_interval_ms = interval_ms;
+        self
+    }
+
+    /// Set message buffer size.
+    #[must_use]
+    pub fn buffer_size(mut self, size: usize) -> Self {
+        self.message_buffer_size = size;
+        self
+    }
+
+    /// Set connection timeout in milliseconds.
+    #[must_use]
+    pub fn connection_timeout(mut self, timeout_ms: u64) -> Self {
+        self.connection_timeout_ms = timeout_ms;
+        self
+    }
+}
+
+/// WebSocket stream type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StreamType {
+    /// Stock market data stream (IEX or SIP).
+    Stocks,
+    /// Cryptocurrency market data stream.
+    Crypto,
+    /// Options market data stream.
+    Options,
+    /// News stream.
+    News,
+    /// Trading updates stream (order fills, etc.).
+    Trading,
+}
+
+impl StreamType {
+    /// Get the WebSocket URL for this stream type.
+    #[must_use]
+    pub fn url(&self, is_paper: bool) -> &'static str {
+        match self {
+            StreamType::Stocks => {
+                if is_paper {
+                    "wss://stream.data.alpaca.markets/v2/iex"
+                } else {
+                    "wss://stream.data.alpaca.markets/v2/sip"
+                }
+            }
+            StreamType::Crypto => "wss://stream.data.alpaca.markets/v1beta3/crypto/us",
+            StreamType::Options => "wss://stream.data.alpaca.markets/v1beta1/options",
+            StreamType::News => "wss://stream.data.alpaca.markets/v1beta1/news",
+            StreamType::Trading => {
+                if is_paper {
+                    "wss://paper-api.alpaca.markets/stream"
+                } else {
+                    "wss://api.alpaca.markets/stream"
+                }
+            }
+        }
+    }
+}
+
+/// Connection state for WebSocket.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConnectionState {
+    /// Not connected.
+    Disconnected,
+    /// Attempting to connect.
+    Connecting,
+    /// Connected and authenticated.
+    Connected,
+    /// Reconnecting after disconnect.
+    Reconnecting,
+    /// Connection failed permanently.
+    Failed,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_websocket_config_default() {
+        let config = WebSocketConfig::default();
+        assert!(config.reconnect_enabled);
+        assert_eq!(config.reconnect_max_attempts, 10);
+        assert_eq!(config.reconnect_base_delay_ms, 1000);
+    }
+
+    #[test]
+    fn test_websocket_config_builder() {
+        let config = WebSocketConfig::new()
+            .no_reconnect()
+            .max_reconnect_attempts(5)
+            .ping_interval(15000)
+            .buffer_size(500);
+
+        assert!(!config.reconnect_enabled);
+        assert_eq!(config.reconnect_max_attempts, 5);
+        assert_eq!(config.ping_interval_ms, 15000);
+        assert_eq!(config.message_buffer_size, 500);
+    }
+
+    #[test]
+    fn test_stream_type_urls() {
+        assert_eq!(
+            StreamType::Stocks.url(true),
+            "wss://stream.data.alpaca.markets/v2/iex"
+        );
+        assert_eq!(
+            StreamType::Stocks.url(false),
+            "wss://stream.data.alpaca.markets/v2/sip"
+        );
+        assert_eq!(
+            StreamType::Crypto.url(true),
+            "wss://stream.data.alpaca.markets/v1beta3/crypto/us"
+        );
+        assert_eq!(
+            StreamType::Options.url(true),
+            "wss://stream.data.alpaca.markets/v1beta1/options"
+        );
+    }
+}

--- a/alpaca-websocket/src/lib.rs
+++ b/alpaca-websocket/src/lib.rs
@@ -4,12 +4,14 @@
 //! This crate provides real-time market data and trading updates via WebSocket connections.
 
 pub mod client;
+pub mod config;
 pub mod error;
 pub mod messages;
 pub mod streams;
 
 pub use alpaca_base::*;
 pub use client::AlpacaWebSocketClient;
+pub use config::{ConnectionState, StreamType, WebSocketConfig};
 pub use error::WebSocketError;
 pub use messages::*;
 pub use streams::*;

--- a/alpaca-websocket/src/messages.rs
+++ b/alpaca-websocket/src/messages.rs
@@ -315,3 +315,313 @@ impl From<BarMessage> for Bar {
         }
     }
 }
+
+// ============================================================================
+// Enhanced WebSocket Message Types
+// ============================================================================
+
+/// Crypto trade message from WebSocket.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CryptoTradeMessage {
+    /// Symbol.
+    #[serde(rename = "S")]
+    pub symbol: String,
+    /// Timestamp.
+    #[serde(rename = "t")]
+    pub timestamp: DateTime<Utc>,
+    /// Trade price.
+    #[serde(rename = "p")]
+    pub price: f64,
+    /// Trade size.
+    #[serde(rename = "s")]
+    pub size: f64,
+    /// Taker side (buy or sell).
+    #[serde(rename = "tks")]
+    pub taker_side: String,
+    /// Trade ID.
+    #[serde(rename = "i")]
+    pub id: u64,
+}
+
+/// Crypto quote message from WebSocket.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CryptoQuoteMessage {
+    /// Symbol.
+    #[serde(rename = "S")]
+    pub symbol: String,
+    /// Timestamp.
+    #[serde(rename = "t")]
+    pub timestamp: DateTime<Utc>,
+    /// Bid price.
+    #[serde(rename = "bp")]
+    pub bid_price: f64,
+    /// Bid size.
+    #[serde(rename = "bs")]
+    pub bid_size: f64,
+    /// Ask price.
+    #[serde(rename = "ap")]
+    pub ask_price: f64,
+    /// Ask size.
+    #[serde(rename = "as")]
+    pub ask_size: f64,
+}
+
+/// Crypto bar message from WebSocket.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CryptoBarMessage {
+    /// Symbol.
+    #[serde(rename = "S")]
+    pub symbol: String,
+    /// Timestamp.
+    #[serde(rename = "t")]
+    pub timestamp: DateTime<Utc>,
+    /// Open price.
+    #[serde(rename = "o")]
+    pub open: f64,
+    /// High price.
+    #[serde(rename = "h")]
+    pub high: f64,
+    /// Low price.
+    #[serde(rename = "l")]
+    pub low: f64,
+    /// Close price.
+    #[serde(rename = "c")]
+    pub close: f64,
+    /// Volume.
+    #[serde(rename = "v")]
+    pub volume: f64,
+    /// Number of trades.
+    #[serde(rename = "n")]
+    pub trade_count: Option<u64>,
+    /// Volume-weighted average price.
+    #[serde(rename = "vw")]
+    pub vwap: Option<f64>,
+}
+
+/// Options trade message from WebSocket.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OptionTradeMessage {
+    /// Option symbol (OCC format).
+    #[serde(rename = "S")]
+    pub symbol: String,
+    /// Timestamp.
+    #[serde(rename = "t")]
+    pub timestamp: DateTime<Utc>,
+    /// Trade price.
+    #[serde(rename = "p")]
+    pub price: f64,
+    /// Trade size (number of contracts).
+    #[serde(rename = "s")]
+    pub size: u32,
+    /// Exchange.
+    #[serde(rename = "x")]
+    pub exchange: String,
+    /// Trade conditions.
+    #[serde(rename = "c", default)]
+    pub conditions: Option<String>,
+}
+
+/// Options quote message from WebSocket.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OptionQuoteMessage {
+    /// Option symbol (OCC format).
+    #[serde(rename = "S")]
+    pub symbol: String,
+    /// Timestamp.
+    #[serde(rename = "t")]
+    pub timestamp: DateTime<Utc>,
+    /// Bid price.
+    #[serde(rename = "bp")]
+    pub bid_price: f64,
+    /// Bid size.
+    #[serde(rename = "bs")]
+    pub bid_size: u32,
+    /// Ask price.
+    #[serde(rename = "ap")]
+    pub ask_price: f64,
+    /// Ask size.
+    #[serde(rename = "as")]
+    pub ask_size: u32,
+    /// Bid exchange.
+    #[serde(rename = "bx")]
+    pub bid_exchange: String,
+    /// Ask exchange.
+    #[serde(rename = "ax")]
+    pub ask_exchange: String,
+}
+
+/// News message from WebSocket.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NewsMessage {
+    /// News ID.
+    pub id: u64,
+    /// Headline.
+    pub headline: String,
+    /// Summary.
+    pub summary: Option<String>,
+    /// Author.
+    pub author: Option<String>,
+    /// Creation timestamp.
+    pub created_at: DateTime<Utc>,
+    /// Update timestamp.
+    pub updated_at: DateTime<Utc>,
+    /// URL to full article.
+    pub url: Option<String>,
+    /// Related symbols.
+    pub symbols: Vec<String>,
+    /// Source.
+    pub source: String,
+}
+
+/// Limit Up Limit Down (LULD) message from WebSocket.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LuldMessage {
+    /// Symbol.
+    #[serde(rename = "S")]
+    pub symbol: String,
+    /// Timestamp.
+    #[serde(rename = "t")]
+    pub timestamp: DateTime<Utc>,
+    /// LULD indicator.
+    #[serde(rename = "i")]
+    pub indicator: String,
+    /// Limit up price.
+    #[serde(rename = "u")]
+    pub limit_up_price: f64,
+    /// Limit down price.
+    #[serde(rename = "d")]
+    pub limit_down_price: f64,
+}
+
+/// Trading status message from WebSocket.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TradingStatusMessage {
+    /// Symbol.
+    #[serde(rename = "S")]
+    pub symbol: String,
+    /// Timestamp.
+    #[serde(rename = "t")]
+    pub timestamp: DateTime<Utc>,
+    /// Status code.
+    #[serde(rename = "sc")]
+    pub status_code: String,
+    /// Status message.
+    #[serde(rename = "sm")]
+    pub status_message: String,
+    /// Reason code.
+    #[serde(rename = "rc")]
+    pub reason_code: String,
+    /// Reason message.
+    #[serde(rename = "rm")]
+    pub reason_message: String,
+}
+
+/// Trade correction message from WebSocket.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CorrectionMessage {
+    /// Symbol.
+    #[serde(rename = "S")]
+    pub symbol: String,
+    /// Timestamp.
+    #[serde(rename = "t")]
+    pub timestamp: DateTime<Utc>,
+    /// Original trade ID.
+    #[serde(rename = "x")]
+    pub original_id: u64,
+    /// Original price.
+    #[serde(rename = "op")]
+    pub original_price: f64,
+    /// Original size.
+    #[serde(rename = "os")]
+    pub original_size: u32,
+    /// Corrected price.
+    #[serde(rename = "cp")]
+    pub corrected_price: f64,
+    /// Corrected size.
+    #[serde(rename = "cs")]
+    pub corrected_size: u32,
+}
+
+/// Cancel error message from WebSocket.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CancelErrorMessage {
+    /// Symbol.
+    #[serde(rename = "S")]
+    pub symbol: String,
+    /// Timestamp.
+    #[serde(rename = "t")]
+    pub timestamp: DateTime<Utc>,
+    /// Trade ID that was canceled in error.
+    #[serde(rename = "i")]
+    pub id: u64,
+    /// Original price.
+    #[serde(rename = "p")]
+    pub price: f64,
+    /// Original size.
+    #[serde(rename = "s")]
+    pub size: u32,
+}
+
+/// Daily bar message from WebSocket.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DailyBarMessage {
+    /// Symbol.
+    #[serde(rename = "S")]
+    pub symbol: String,
+    /// Timestamp.
+    #[serde(rename = "t")]
+    pub timestamp: DateTime<Utc>,
+    /// Open price.
+    #[serde(rename = "o")]
+    pub open: f64,
+    /// High price.
+    #[serde(rename = "h")]
+    pub high: f64,
+    /// Low price.
+    #[serde(rename = "l")]
+    pub low: f64,
+    /// Close price.
+    #[serde(rename = "c")]
+    pub close: f64,
+    /// Volume.
+    #[serde(rename = "v")]
+    pub volume: u64,
+    /// Volume-weighted average price.
+    #[serde(rename = "vw")]
+    pub vwap: Option<f64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_subscription_builder() {
+        let sub = SubscriptionBuilder::new()
+            .trades(["AAPL", "MSFT"])
+            .quotes(["GOOGL"])
+            .trade_updates()
+            .build();
+
+        assert_eq!(
+            sub.trades,
+            Some(vec!["AAPL".to_string(), "MSFT".to_string()])
+        );
+        assert_eq!(sub.quotes, Some(vec!["GOOGL".to_string()]));
+        assert_eq!(sub.trade_updates, Some(true));
+    }
+
+    #[test]
+    fn test_trade_update_event_serialization() {
+        let event = TradeUpdateEvent::Fill;
+        let json = serde_json::to_string(&event).unwrap();
+        assert_eq!(json, "\"fill\"");
+    }
+
+    #[test]
+    fn test_connection_status_serialization() {
+        let status = ConnectionStatus::Connected;
+        let json = serde_json::to_string(&status).unwrap();
+        assert_eq!(json, "\"connected\"");
+    }
+}


### PR DESCRIPTION
## Summary

Implements Issue #11 - Enhanced WebSocket Streaming. This PR adds comprehensive WebSocket streaming enhancements including configuration, multiple stream types, and new message types.

## Changes

### Configuration (alpaca-websocket v0.2.0)
- `WebSocketConfig` struct with builder pattern:
  - reconnect_enabled, reconnect_max_attempts
  - reconnect_base_delay_ms, reconnect_max_delay_ms
  - ping_interval_ms, message_buffer_size
  - connection_timeout_ms
- `StreamType` enum: Stocks, Crypto, Options, News, Trading
- `ConnectionState` enum: Disconnected, Connecting, Connected, Reconnecting, Failed

### New Message Types
- `CryptoTradeMessage`, `CryptoQuoteMessage`, `CryptoBarMessage`
- `OptionTradeMessage`, `OptionQuoteMessage`
- `NewsMessage` for real-time news
- `LuldMessage` for Limit Up Limit Down data
- `TradingStatusMessage` for trading halts
- `CorrectionMessage` for trade corrections
- `CancelErrorMessage` for cancel errors
- `DailyBarMessage` for daily bars

## Testing

- Unit tests: 68 tests (6 new for WebSocket)
- All tests pass: `make test`
- Linting passes: `make pre-push`

## Checklist

- [x] Version bumped (alpaca-websocket: 0.2.0)
- [x] Unit tests added (6 new tests)
- [x] `make pre-push` passes

Closes #11