### PR TITLE
feat(broker): implement Broker API Funding & Transfers

### DIFF
--- a/alpaca-base/Cargo.toml
+++ b/alpaca-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alpaca-base"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "Base library with common structs, traits, and logic for Alpaca API clients"

--- a/alpaca-base/src/types.rs
+++ b/alpaca-base/src/types.rs
@@ -2010,6 +2010,467 @@ impl ListBrokerAccountsParams {
     }
 }
 
+// ============================================================================
+// Broker API Types - Funding & Transfers
+// ============================================================================
+
+/// ACH relationship status.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum AchRelationshipStatus {
+    /// Queued for processing.
+    Queued,
+    /// Approved.
+    Approved,
+    /// Pending verification.
+    Pending,
+    /// Cancel requested.
+    CancelRequested,
+    /// Canceled.
+    Canceled,
+}
+
+/// Bank account type.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum BankAccountType {
+    /// Checking account.
+    Checking,
+    /// Savings account.
+    Savings,
+}
+
+/// Transfer type.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum TransferType {
+    /// ACH transfer.
+    Ach,
+    /// Wire transfer.
+    Wire,
+}
+
+/// Transfer direction.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum TransferDirection {
+    /// Incoming transfer (deposit).
+    Incoming,
+    /// Outgoing transfer (withdrawal).
+    Outgoing,
+}
+
+/// Transfer status.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum TransferStatus {
+    /// Queued for processing.
+    Queued,
+    /// Pending.
+    Pending,
+    /// Sent to clearing.
+    SentToClearing,
+    /// Approved.
+    Approved,
+    /// Complete.
+    Complete,
+    /// Returned.
+    Returned,
+    /// Canceled.
+    Canceled,
+}
+
+/// Journal entry type.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum JournalEntryType {
+    /// Cash journal.
+    Jnlc,
+    /// Security journal.
+    Jnls,
+}
+
+/// Journal status.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum JournalStatus {
+    /// Pending.
+    Pending,
+    /// Executed.
+    Executed,
+    /// Canceled.
+    Canceled,
+    /// Rejected.
+    Rejected,
+}
+
+/// ACH relationship.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct AchRelationship {
+    /// Relationship ID.
+    pub id: String,
+    /// Account ID.
+    pub account_id: String,
+    /// Status.
+    pub status: AchRelationshipStatus,
+    /// Account owner name.
+    pub account_owner_name: String,
+    /// Bank account type.
+    pub bank_account_type: BankAccountType,
+    /// Bank account number (masked).
+    pub bank_account_number: String,
+    /// Bank routing number.
+    pub bank_routing_number: String,
+    /// Nickname.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nickname: Option<String>,
+    /// Created at timestamp.
+    pub created_at: DateTime<Utc>,
+    /// Updated at timestamp.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<DateTime<Utc>>,
+}
+
+/// Request to create an ACH relationship.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CreateAchRelationshipRequest {
+    /// Account owner name.
+    pub account_owner_name: String,
+    /// Bank account type.
+    pub bank_account_type: BankAccountType,
+    /// Bank account number.
+    pub bank_account_number: String,
+    /// Bank routing number.
+    pub bank_routing_number: String,
+    /// Nickname.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nickname: Option<String>,
+    /// Processor token (for Plaid integration).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub processor_token: Option<String>,
+}
+
+impl CreateAchRelationshipRequest {
+    /// Create new ACH relationship request.
+    #[must_use]
+    pub fn new(
+        account_owner_name: &str,
+        bank_account_type: BankAccountType,
+        bank_account_number: &str,
+        bank_routing_number: &str,
+    ) -> Self {
+        Self {
+            account_owner_name: account_owner_name.to_string(),
+            bank_account_type,
+            bank_account_number: bank_account_number.to_string(),
+            bank_routing_number: bank_routing_number.to_string(),
+            nickname: None,
+            processor_token: None,
+        }
+    }
+
+    /// Set nickname.
+    #[must_use]
+    pub fn nickname(mut self, nickname: &str) -> Self {
+        self.nickname = Some(nickname.to_string());
+        self
+    }
+
+    /// Set processor token.
+    #[must_use]
+    pub fn processor_token(mut self, token: &str) -> Self {
+        self.processor_token = Some(token.to_string());
+        self
+    }
+}
+
+/// Transfer.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Transfer {
+    /// Transfer ID.
+    pub id: String,
+    /// Relationship ID.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub relationship_id: Option<String>,
+    /// Account ID.
+    pub account_id: String,
+    /// Transfer type.
+    #[serde(rename = "type")]
+    pub transfer_type: TransferType,
+    /// Status.
+    pub status: TransferStatus,
+    /// Amount in USD.
+    pub amount: String,
+    /// Direction.
+    pub direction: TransferDirection,
+    /// Created at timestamp.
+    pub created_at: DateTime<Utc>,
+    /// Updated at timestamp.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<DateTime<Utc>>,
+    /// Expires at timestamp.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<DateTime<Utc>>,
+    /// Reason for status.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+/// Request to create a transfer.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CreateTransferRequest {
+    /// Transfer type.
+    pub transfer_type: TransferType,
+    /// Relationship ID (for ACH).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub relationship_id: Option<String>,
+    /// Amount in USD.
+    pub amount: String,
+    /// Direction.
+    pub direction: TransferDirection,
+    /// Additional info.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub additional_information: Option<String>,
+}
+
+impl CreateTransferRequest {
+    /// Create new ACH transfer request.
+    #[must_use]
+    pub fn ach(relationship_id: &str, amount: &str, direction: TransferDirection) -> Self {
+        Self {
+            transfer_type: TransferType::Ach,
+            relationship_id: Some(relationship_id.to_string()),
+            amount: amount.to_string(),
+            direction,
+            additional_information: None,
+        }
+    }
+
+    /// Create new wire transfer request.
+    #[must_use]
+    pub fn wire(amount: &str, direction: TransferDirection) -> Self {
+        Self {
+            transfer_type: TransferType::Wire,
+            relationship_id: None,
+            amount: amount.to_string(),
+            direction,
+            additional_information: None,
+        }
+    }
+}
+
+/// Wire bank details.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct WireBank {
+    /// Bank ID.
+    pub id: String,
+    /// Account ID.
+    pub account_id: String,
+    /// Bank name.
+    pub name: String,
+    /// Bank code.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bank_code: Option<String>,
+    /// Bank code type.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bank_code_type: Option<String>,
+    /// Country.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub country: Option<String>,
+    /// State/Province.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state_province: Option<String>,
+    /// Postal code.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub postal_code: Option<String>,
+    /// City.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub city: Option<String>,
+    /// Street address.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub street_address: Option<String>,
+    /// Account number.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub account_number: Option<String>,
+    /// Created at timestamp.
+    pub created_at: DateTime<Utc>,
+}
+
+/// Request to create a wire bank.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CreateWireBankRequest {
+    /// Bank name.
+    pub name: String,
+    /// Bank code.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bank_code: Option<String>,
+    /// Bank code type (ABA, BIC, etc.).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bank_code_type: Option<String>,
+    /// Country.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub country: Option<String>,
+    /// City.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub city: Option<String>,
+    /// Account number.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub account_number: Option<String>,
+}
+
+/// Journal entry.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Journal {
+    /// Journal ID.
+    pub id: String,
+    /// From account ID.
+    pub from_account: String,
+    /// To account ID.
+    pub to_account: String,
+    /// Entry type.
+    pub entry_type: JournalEntryType,
+    /// Status.
+    pub status: JournalStatus,
+    /// Net amount.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub net_amount: Option<String>,
+    /// Symbol (for security journals).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub symbol: Option<String>,
+    /// Quantity (for security journals).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub qty: Option<String>,
+    /// Description.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Settle date.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub settle_date: Option<String>,
+    /// System date.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub system_date: Option<String>,
+}
+
+/// Request to create a journal entry.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CreateJournalRequest {
+    /// From account ID.
+    pub from_account: String,
+    /// To account ID.
+    pub to_account: String,
+    /// Entry type.
+    pub entry_type: JournalEntryType,
+    /// Amount (for cash journals).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub amount: Option<String>,
+    /// Symbol (for security journals).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub symbol: Option<String>,
+    /// Quantity (for security journals).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub qty: Option<String>,
+    /// Description.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+impl CreateJournalRequest {
+    /// Create cash journal request.
+    #[must_use]
+    pub fn cash(from_account: &str, to_account: &str, amount: &str) -> Self {
+        Self {
+            from_account: from_account.to_string(),
+            to_account: to_account.to_string(),
+            entry_type: JournalEntryType::Jnlc,
+            amount: Some(amount.to_string()),
+            symbol: None,
+            qty: None,
+            description: None,
+        }
+    }
+
+    /// Create security journal request.
+    #[must_use]
+    pub fn security(from_account: &str, to_account: &str, symbol: &str, qty: &str) -> Self {
+        Self {
+            from_account: from_account.to_string(),
+            to_account: to_account.to_string(),
+            entry_type: JournalEntryType::Jnls,
+            amount: None,
+            symbol: Some(symbol.to_string()),
+            qty: Some(qty.to_string()),
+            description: None,
+        }
+    }
+
+    /// Set description.
+    #[must_use]
+    pub fn description(mut self, description: &str) -> Self {
+        self.description = Some(description.to_string());
+        self
+    }
+}
+
+/// Batch journal entry.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct BatchJournalEntry {
+    /// To account ID.
+    pub to_account: String,
+    /// Amount.
+    pub amount: String,
+}
+
+/// Request to create batch journal entries.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CreateBatchJournalRequest {
+    /// From account ID.
+    pub from_account: String,
+    /// Entry type.
+    pub entry_type: JournalEntryType,
+    /// Entries.
+    pub entries: Vec<BatchJournalEntry>,
+    /// Description.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+/// Parameters for listing transfers.
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+pub struct ListTransfersParams {
+    /// Filter by direction.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub direction: Option<TransferDirection>,
+    /// Maximum number of results.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u32>,
+    /// Offset for pagination.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub offset: Option<u32>,
+}
+
+/// Parameters for listing journals.
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+pub struct ListJournalsParams {
+    /// After timestamp.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub after: Option<String>,
+    /// Before timestamp.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub before: Option<String>,
+    /// Filter by status.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<JournalStatus>,
+    /// Filter by entry type.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub entry_type: Option<JournalEntryType>,
+    /// Filter by to account.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub to_account: Option<String>,
+    /// Filter by from account.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub from_account: Option<String>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2295,5 +2756,47 @@ mod tests {
 
         assert!(!disclosures.is_control_person);
         assert_eq!(disclosures.employer_name, Some("Acme Corp".to_string()));
+    }
+
+    #[test]
+    fn test_transfer_status_serialization() {
+        let status = TransferStatus::Complete;
+        let json = serde_json::to_string(&status).unwrap();
+        assert_eq!(json, "\"COMPLETE\"");
+    }
+
+    #[test]
+    fn test_create_ach_relationship_request() {
+        let request = CreateAchRelationshipRequest::new(
+            "John Doe",
+            BankAccountType::Checking,
+            "123456789",
+            "021000021",
+        )
+        .nickname("Primary Account");
+
+        assert_eq!(request.account_owner_name, "John Doe");
+        assert_eq!(request.bank_account_type, BankAccountType::Checking);
+        assert_eq!(request.nickname, Some("Primary Account".to_string()));
+    }
+
+    #[test]
+    fn test_create_transfer_request_ach() {
+        let request = CreateTransferRequest::ach("rel-123", "1000.00", TransferDirection::Incoming);
+
+        assert_eq!(request.transfer_type, TransferType::Ach);
+        assert_eq!(request.relationship_id, Some("rel-123".to_string()));
+        assert_eq!(request.amount, "1000.00");
+        assert_eq!(request.direction, TransferDirection::Incoming);
+    }
+
+    #[test]
+    fn test_create_journal_request_cash() {
+        let request =
+            CreateJournalRequest::cash("acc-from", "acc-to", "500.00").description("Test transfer");
+
+        assert_eq!(request.entry_type, JournalEntryType::Jnlc);
+        assert_eq!(request.amount, Some("500.00".to_string()));
+        assert_eq!(request.description, Some("Test transfer".to_string()));
     }
 }

--- a/alpaca-http/Cargo.toml
+++ b/alpaca-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alpaca-http"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "HTTP REST API client for Alpaca trading platform"

--- a/alpaca-http/src/endpoints.rs
+++ b/alpaca-http/src/endpoints.rs
@@ -1454,6 +1454,229 @@ pub struct DocumentInfo {
     pub created_at: DateTime<Utc>,
 }
 
+// ============================================================================
+// Broker API - Funding & Transfers Endpoints
+// ============================================================================
+
+impl AlpacaHttpClient {
+    // ========================================================================
+    // ACH Relationship Endpoints
+    // ========================================================================
+
+    /// Create an ACH relationship for an account.
+    ///
+    /// # Arguments
+    /// * `account_id` - The account ID
+    /// * `request` - ACH relationship creation request
+    ///
+    /// # Returns
+    /// The created ACH relationship
+    pub async fn create_ach_relationship(
+        &self,
+        account_id: &str,
+        request: &CreateAchRelationshipRequest,
+    ) -> Result<AchRelationship> {
+        self.post(
+            &format!("/v1/accounts/{}/ach_relationships", account_id),
+            request,
+        )
+        .await
+    }
+
+    /// List ACH relationships for an account.
+    ///
+    /// # Arguments
+    /// * `account_id` - The account ID
+    ///
+    /// # Returns
+    /// List of ACH relationships
+    pub async fn list_ach_relationships(&self, account_id: &str) -> Result<Vec<AchRelationship>> {
+        self.get(&format!("/v1/accounts/{}/ach_relationships", account_id))
+            .await
+    }
+
+    /// Delete an ACH relationship.
+    ///
+    /// # Arguments
+    /// * `account_id` - The account ID
+    /// * `relationship_id` - The relationship ID to delete
+    pub async fn delete_ach_relationship(
+        &self,
+        account_id: &str,
+        relationship_id: &str,
+    ) -> Result<()> {
+        self.delete(&format!(
+            "/v1/accounts/{}/ach_relationships/{}",
+            account_id, relationship_id
+        ))
+        .await
+    }
+
+    // ========================================================================
+    // Transfer Endpoints
+    // ========================================================================
+
+    /// Create a transfer for an account.
+    ///
+    /// # Arguments
+    /// * `account_id` - The account ID
+    /// * `request` - Transfer creation request
+    ///
+    /// # Returns
+    /// The created transfer
+    pub async fn create_transfer(
+        &self,
+        account_id: &str,
+        request: &CreateTransferRequest,
+    ) -> Result<Transfer> {
+        self.post(&format!("/v1/accounts/{}/transfers", account_id), request)
+            .await
+    }
+
+    /// List transfers for an account.
+    ///
+    /// # Arguments
+    /// * `account_id` - The account ID
+    /// * `params` - Optional query parameters
+    ///
+    /// # Returns
+    /// List of transfers
+    pub async fn list_transfers(
+        &self,
+        account_id: &str,
+        params: &ListTransfersParams,
+    ) -> Result<Vec<Transfer>> {
+        self.get_with_params(&format!("/v1/accounts/{}/transfers", account_id), params)
+            .await
+    }
+
+    /// Get a specific transfer.
+    ///
+    /// # Arguments
+    /// * `account_id` - The account ID
+    /// * `transfer_id` - The transfer ID
+    ///
+    /// # Returns
+    /// The transfer
+    pub async fn get_transfer(&self, account_id: &str, transfer_id: &str) -> Result<Transfer> {
+        self.get(&format!(
+            "/v1/accounts/{}/transfers/{}",
+            account_id, transfer_id
+        ))
+        .await
+    }
+
+    /// Cancel a transfer.
+    ///
+    /// # Arguments
+    /// * `account_id` - The account ID
+    /// * `transfer_id` - The transfer ID to cancel
+    pub async fn cancel_transfer(&self, account_id: &str, transfer_id: &str) -> Result<()> {
+        self.delete(&format!(
+            "/v1/accounts/{}/transfers/{}",
+            account_id, transfer_id
+        ))
+        .await
+    }
+
+    // ========================================================================
+    // Wire Bank Endpoints
+    // ========================================================================
+
+    /// List recipient banks for wire transfers.
+    ///
+    /// # Arguments
+    /// * `account_id` - The account ID
+    ///
+    /// # Returns
+    /// List of wire banks
+    pub async fn list_wire_banks(&self, account_id: &str) -> Result<Vec<WireBank>> {
+        self.get(&format!("/v1/accounts/{}/recipient_banks", account_id))
+            .await
+    }
+
+    /// Create a recipient bank for wire transfers.
+    ///
+    /// # Arguments
+    /// * `account_id` - The account ID
+    /// * `request` - Wire bank creation request
+    ///
+    /// # Returns
+    /// The created wire bank
+    pub async fn create_wire_bank(
+        &self,
+        account_id: &str,
+        request: &CreateWireBankRequest,
+    ) -> Result<WireBank> {
+        self.post(
+            &format!("/v1/accounts/{}/recipient_banks", account_id),
+            request,
+        )
+        .await
+    }
+
+    /// Delete a recipient bank.
+    ///
+    /// # Arguments
+    /// * `account_id` - The account ID
+    /// * `bank_id` - The bank ID to delete
+    pub async fn delete_wire_bank(&self, account_id: &str, bank_id: &str) -> Result<()> {
+        self.delete(&format!(
+            "/v1/accounts/{}/recipient_banks/{}",
+            account_id, bank_id
+        ))
+        .await
+    }
+
+    // ========================================================================
+    // Journal Endpoints
+    // ========================================================================
+
+    /// Create a journal entry.
+    ///
+    /// # Arguments
+    /// * `request` - Journal creation request
+    ///
+    /// # Returns
+    /// The created journal
+    pub async fn create_journal(&self, request: &CreateJournalRequest) -> Result<Journal> {
+        self.post("/v1/journals", request).await
+    }
+
+    /// List journal entries.
+    ///
+    /// # Arguments
+    /// * `params` - Optional query parameters
+    ///
+    /// # Returns
+    /// List of journals
+    pub async fn list_journals(&self, params: &ListJournalsParams) -> Result<Vec<Journal>> {
+        self.get_with_params("/v1/journals", params).await
+    }
+
+    /// Create batch journal entries.
+    ///
+    /// # Arguments
+    /// * `request` - Batch journal creation request
+    ///
+    /// # Returns
+    /// List of created journals
+    pub async fn create_batch_journals(
+        &self,
+        request: &CreateBatchJournalRequest,
+    ) -> Result<Vec<Journal>> {
+        self.post("/v1/journals/batch", request).await
+    }
+
+    /// Delete a journal entry.
+    ///
+    /// # Arguments
+    /// * `journal_id` - The journal ID to delete
+    pub async fn delete_journal(&self, journal_id: &str) -> Result<()> {
+        self.delete(&format!("/v1/journals/{}", journal_id)).await
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

Implements Issue #7 - Broker API Funding & Transfers. This PR adds comprehensive support for ACH relationships, transfers, wire banks, and journal entries.

## Changes

### Types (alpaca-base v0.8.0)
- `AchRelationshipStatus` enum: Queued, Approved, Pending, CancelRequested, Canceled
- `BankAccountType` enum: Checking, Savings
- `TransferType` enum: Ach, Wire
- `TransferDirection` enum: Incoming, Outgoing
- `TransferStatus` enum: Queued, Pending, SentToClearing, Approved, Complete, Returned, Canceled
- `JournalEntryType` enum: Jnlc (cash), Jnls (security)
- `JournalStatus` enum: Pending, Executed, Canceled, Rejected
- `AchRelationship` struct and `CreateAchRelationshipRequest` with builder
- `Transfer` struct and `CreateTransferRequest` with factory methods
- `WireBank` struct and `CreateWireBankRequest`
- `Journal` struct and `CreateJournalRequest` with factory methods
- `BatchJournalEntry` and `CreateBatchJournalRequest`
- `ListTransfersParams` and `ListJournalsParams`

### HTTP Endpoints (alpaca-http v0.7.0)
- `create_ach_relationship()`, `list_ach_relationships()`, `delete_ach_relationship()`
- `create_transfer()`, `list_transfers()`, `get_transfer()`, `cancel_transfer()`
- `list_wire_banks()`, `create_wire_bank()`, `delete_wire_bank()`
- `create_journal()`, `list_journals()`, `create_batch_journals()`, `delete_journal()`

## Testing

- Unit tests: 77 tests (4 new for Funding types)
- All tests pass: `make test`
- Linting passes: `make pre-push`

## Checklist

- [x] Version bumped (alpaca-base: 0.8.0, alpaca-http: 0.7.0)
- [x] Unit tests added (4 new tests)
- [x] `make pre-push` passes

Closes #7