### PR TITLE
feat(crypto): implement Enhanced Crypto Trading

### DIFF
--- a/alpaca-base/Cargo.toml
+++ b/alpaca-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alpaca-base"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "Base library with common structs, traits, and logic for Alpaca API clients"

--- a/alpaca-base/README.md
+++ b/alpaca-base/README.md
@@ -1,0 +1,65 @@
+# alpaca-base
+
+Base library with common structs, traits, and logic for Alpaca API clients.
+
+## Overview
+
+`alpaca-base` provides the foundational building blocks for the Alpaca Market API Rust clients. It includes shared data models, authentication utilities, custom error types, and common helper functions used by both `alpaca-http` and `alpaca-websocket`.
+
+## Features
+
+- **Core Data Models**: Comprehensive Rust representations of Alpaca API objects (Orders, Positions, Assets, etc.).
+- **Authentication**: Utilities for managing API keys and generating authentication headers.
+- **Robust Error Handling**: Centralized error types for API errors, validation errors, and rate limits.
+- **Utility Functions**: Helpers for URL encoding, timestamp parsing, and more.
+- **Test Utilities**: Fixtures and helpers for testing Alpaca integrations (available with `test-utils` feature).
+
+## Installation
+
+Add to your `Cargo.toml`:
+
+```toml
+[dependencies]
+alpaca-base = "0.8.0"
+```
+
+## Usage
+
+While `alpaca-base` is primarily used internally by other crates in the workspace, you can use its types and authentication utilities directly.
+
+```rust
+use alpaca_base::auth::AlpacaCredentials;
+
+let credentials = AlpacaCredentials::new(
+    "your_api_key".to_string(),
+    "your_api_secret".to_string(),
+    false, // paper trading
+);
+```
+
+## API Reference
+
+### Main Modules
+
+- `auth` - Authentication types and credentials management.
+- `error` - `AlpacaError` and related API error types.
+- `types` - Core data structures (Account, Order, Position, etc.).
+- `utils` - Common helper functions.
+
+### Main Types
+
+- `AlpacaCredentials` - Stores and manages API credentials.
+- `AlpacaError` - Unified error type for the entire library.
+- `Order` - Representation of an Alpaca order.
+- `Account` - Representation of an Alpaca account.
+
+## Changelog
+
+### v0.8.0 (latest)
+- Initial workspace consolidation.
+- Enhanced error handling with `thiserror`.
+- Comprehensive API models updated to latest Alpaca specification.
+
+## License
+
+MIT

--- a/alpaca-base/src/types.rs
+++ b/alpaca-base/src/types.rs
@@ -2471,6 +2471,377 @@ pub struct ListJournalsParams {
     pub from_account: Option<String>,
 }
 
+// ============================================================================
+// Enhanced Crypto Trading Types
+// ============================================================================
+
+/// Crypto blockchain chain.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum CryptoChain {
+    /// Bitcoin.
+    Btc,
+    /// Ethereum.
+    Eth,
+    /// Solana.
+    Sol,
+    /// Avalanche.
+    Avax,
+    /// Polygon.
+    Matic,
+    /// Arbitrum.
+    Arb,
+    /// Base.
+    Base,
+}
+
+/// Crypto transfer status.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum CryptoTransferStatus {
+    /// Pending approval.
+    Pending,
+    /// Approved.
+    Approved,
+    /// Pending send to blockchain.
+    PendingSend,
+    /// Sent to blockchain.
+    Sent,
+    /// Complete.
+    Complete,
+    /// Rejected.
+    Rejected,
+    /// Failed.
+    Failed,
+}
+
+/// Crypto transfer direction.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum CryptoTransferDirection {
+    /// Incoming (deposit).
+    Incoming,
+    /// Outgoing (withdrawal).
+    Outgoing,
+}
+
+/// Crypto wallet status.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum CryptoWalletStatus {
+    /// Active.
+    Active,
+    /// Inactive.
+    Inactive,
+    /// Pending.
+    Pending,
+}
+
+/// Broker crypto wallet for Broker API.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct BrokerCryptoWallet {
+    /// Wallet ID.
+    pub id: String,
+    /// Account ID.
+    pub account_id: String,
+    /// Asset symbol (e.g., BTC, ETH).
+    pub asset: String,
+    /// Wallet address.
+    pub address: String,
+    /// Blockchain chain.
+    pub chain: CryptoChain,
+    /// Wallet status.
+    pub status: CryptoWalletStatus,
+    /// Created at timestamp.
+    pub created_at: DateTime<Utc>,
+}
+
+/// Request to create a crypto wallet.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CreateCryptoWalletRequest {
+    /// Asset symbol (e.g., BTC, ETH).
+    pub asset: String,
+}
+
+impl CreateCryptoWalletRequest {
+    /// Create new wallet request.
+    #[must_use]
+    pub fn new(asset: &str) -> Self {
+        Self {
+            asset: asset.to_string(),
+        }
+    }
+}
+
+/// Crypto transfer.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CryptoTransfer {
+    /// Transfer ID.
+    pub id: String,
+    /// Wallet ID.
+    pub wallet_id: String,
+    /// Account ID.
+    pub account_id: String,
+    /// Asset symbol.
+    pub asset: String,
+    /// Amount.
+    pub amount: String,
+    /// Direction.
+    pub direction: CryptoTransferDirection,
+    /// Status.
+    pub status: CryptoTransferStatus,
+    /// Fee.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fee: Option<String>,
+    /// Transaction hash.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tx_hash: Option<String>,
+    /// Created at timestamp.
+    pub created_at: DateTime<Utc>,
+    /// Updated at timestamp.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<DateTime<Utc>>,
+}
+
+/// Request to create a crypto transfer.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CreateCryptoTransferRequest {
+    /// Amount to transfer.
+    pub amount: String,
+    /// Destination address (for withdrawals).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address: Option<String>,
+}
+
+impl CreateCryptoTransferRequest {
+    /// Create withdrawal request.
+    #[must_use]
+    pub fn withdrawal(amount: &str, address: &str) -> Self {
+        Self {
+            amount: amount.to_string(),
+            address: Some(address.to_string()),
+        }
+    }
+}
+
+/// Whitelisted crypto address.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CryptoWhitelistAddress {
+    /// Whitelist ID.
+    pub id: String,
+    /// Account ID.
+    pub account_id: String,
+    /// Asset symbol.
+    pub asset: String,
+    /// Whitelisted address.
+    pub address: String,
+    /// Chain.
+    pub chain: CryptoChain,
+    /// Label/nickname.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    /// Created at timestamp.
+    pub created_at: DateTime<Utc>,
+}
+
+/// Request to add a whitelisted address.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CreateCryptoWhitelistRequest {
+    /// Asset symbol.
+    pub asset: String,
+    /// Address to whitelist.
+    pub address: String,
+    /// Label/nickname.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+}
+
+impl CreateCryptoWhitelistRequest {
+    /// Create new whitelist request.
+    #[must_use]
+    pub fn new(asset: &str, address: &str) -> Self {
+        Self {
+            asset: asset.to_string(),
+            address: address.to_string(),
+            label: None,
+        }
+    }
+
+    /// Set label.
+    #[must_use]
+    pub fn label(mut self, label: &str) -> Self {
+        self.label = Some(label.to_string());
+        self
+    }
+}
+
+/// Crypto snapshot with current price data.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CryptoSnapshot {
+    /// Latest trade.
+    #[serde(rename = "latestTrade")]
+    pub latest_trade: Option<CryptoTrade>,
+    /// Latest quote.
+    #[serde(rename = "latestQuote")]
+    pub latest_quote: Option<CryptoQuote>,
+    /// Minute bar.
+    #[serde(rename = "minuteBar")]
+    pub minute_bar: Option<CryptoBar>,
+    /// Daily bar.
+    #[serde(rename = "dailyBar")]
+    pub daily_bar: Option<CryptoBar>,
+    /// Previous daily bar.
+    #[serde(rename = "prevDailyBar")]
+    pub prev_daily_bar: Option<CryptoBar>,
+}
+
+/// Crypto trade data.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CryptoTrade {
+    /// Timestamp.
+    #[serde(rename = "t")]
+    pub timestamp: DateTime<Utc>,
+    /// Price.
+    #[serde(rename = "p")]
+    pub price: f64,
+    /// Size.
+    #[serde(rename = "s")]
+    pub size: f64,
+    /// Taker side.
+    #[serde(rename = "tks")]
+    pub taker_side: String,
+    /// Trade ID.
+    #[serde(rename = "i")]
+    pub id: u64,
+}
+
+/// Crypto quote data.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CryptoQuote {
+    /// Timestamp.
+    #[serde(rename = "t")]
+    pub timestamp: DateTime<Utc>,
+    /// Bid price.
+    #[serde(rename = "bp")]
+    pub bid_price: f64,
+    /// Bid size.
+    #[serde(rename = "bs")]
+    pub bid_size: f64,
+    /// Ask price.
+    #[serde(rename = "ap")]
+    pub ask_price: f64,
+    /// Ask size.
+    #[serde(rename = "as")]
+    pub ask_size: f64,
+}
+
+/// Crypto bar data.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CryptoBar {
+    /// Timestamp.
+    #[serde(rename = "t")]
+    pub timestamp: DateTime<Utc>,
+    /// Open price.
+    #[serde(rename = "o")]
+    pub open: f64,
+    /// High price.
+    #[serde(rename = "h")]
+    pub high: f64,
+    /// Low price.
+    #[serde(rename = "l")]
+    pub low: f64,
+    /// Close price.
+    #[serde(rename = "c")]
+    pub close: f64,
+    /// Volume.
+    #[serde(rename = "v")]
+    pub volume: f64,
+    /// Number of trades.
+    #[serde(rename = "n", skip_serializing_if = "Option::is_none")]
+    pub trade_count: Option<u64>,
+    /// Volume-weighted average price.
+    #[serde(rename = "vw", skip_serializing_if = "Option::is_none")]
+    pub vwap: Option<f64>,
+}
+
+/// Crypto orderbook entry.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CryptoOrderbookEntry {
+    /// Price.
+    #[serde(rename = "p")]
+    pub price: f64,
+    /// Size.
+    #[serde(rename = "s")]
+    pub size: f64,
+}
+
+/// Crypto orderbook.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CryptoOrderbook {
+    /// Timestamp.
+    #[serde(rename = "t")]
+    pub timestamp: DateTime<Utc>,
+    /// Bid entries.
+    #[serde(rename = "b")]
+    pub bids: Vec<CryptoOrderbookEntry>,
+    /// Ask entries.
+    #[serde(rename = "a")]
+    pub asks: Vec<CryptoOrderbookEntry>,
+}
+
+/// Parameters for crypto bars request.
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+pub struct CryptoBarsParams {
+    /// Comma-separated list of symbols.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub symbols: Option<String>,
+    /// Timeframe (e.g., "1Min", "1Hour", "1Day").
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timeframe: Option<String>,
+    /// Start time (RFC3339).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start: Option<String>,
+    /// End time (RFC3339).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub end: Option<String>,
+    /// Maximum number of bars.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u32>,
+}
+
+impl CryptoBarsParams {
+    /// Create new parameters with symbols.
+    #[must_use]
+    pub fn new(symbols: &str) -> Self {
+        Self {
+            symbols: Some(symbols.to_string()),
+            ..Default::default()
+        }
+    }
+
+    /// Set timeframe.
+    #[must_use]
+    pub fn timeframe(mut self, timeframe: &str) -> Self {
+        self.timeframe = Some(timeframe.to_string());
+        self
+    }
+
+    /// Set time range.
+    #[must_use]
+    pub fn time_range(mut self, start: &str, end: &str) -> Self {
+        self.start = Some(start.to_string());
+        self.end = Some(end.to_string());
+        self
+    }
+
+    /// Set limit.
+    #[must_use]
+    pub fn limit(mut self, limit: u32) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2798,5 +3169,40 @@ mod tests {
         assert_eq!(request.entry_type, JournalEntryType::Jnlc);
         assert_eq!(request.amount, Some("500.00".to_string()));
         assert_eq!(request.description, Some("Test transfer".to_string()));
+    }
+
+    #[test]
+    fn test_crypto_chain_serialization() {
+        let chain = CryptoChain::Eth;
+        let json = serde_json::to_string(&chain).unwrap();
+        assert_eq!(json, "\"ETH\"");
+    }
+
+    #[test]
+    fn test_crypto_transfer_status_serialization() {
+        let status = CryptoTransferStatus::Complete;
+        let json = serde_json::to_string(&status).unwrap();
+        assert_eq!(json, "\"COMPLETE\"");
+    }
+
+    #[test]
+    fn test_create_crypto_whitelist_request() {
+        let request =
+            CreateCryptoWhitelistRequest::new("BTC", "bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh")
+                .label("My Hardware Wallet");
+
+        assert_eq!(request.asset, "BTC");
+        assert_eq!(request.label, Some("My Hardware Wallet".to_string()));
+    }
+
+    #[test]
+    fn test_crypto_bars_params_builder() {
+        let params = CryptoBarsParams::new("BTC/USD,ETH/USD")
+            .timeframe("1Hour")
+            .limit(100);
+
+        assert_eq!(params.symbols, Some("BTC/USD,ETH/USD".to_string()));
+        assert_eq!(params.timeframe, Some("1Hour".to_string()));
+        assert_eq!(params.limit, Some(100));
     }
 }

--- a/alpaca-http/Cargo.toml
+++ b/alpaca-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alpaca-http"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "HTTP REST API client for Alpaca trading platform"

--- a/alpaca-http/README.md
+++ b/alpaca-http/README.md
@@ -1,0 +1,75 @@
+# alpaca-http
+
+HTTP REST API client for the Alpaca trading platform.
+
+## Overview
+
+`alpaca-http` provides a high-level, asynchronous Rust client for Alpaca's REST API. It covers trading, market data, and account management endpoints, allowing you to build automated trading systems with ease.
+
+## Features
+
+- **Asynchronous API**: Built on top of `reqwest` and `tokio` for high-performance, non-blocking I/O.
+- **Comprehensive Endpoint Support**:
+    - **Trading**: Place, list, and cancel orders.
+    - **Account**: Get account details, activities, and portfolio history.
+    - **Market Data**: Fetch bars, quotes, and trades for stocks and crypto.
+    - **Assets**: List and query asset information.
+- **Type-Safe Requests**: Structured request and response models for all endpoints.
+- **Automated Authentication**: Handles API key headers and environment-based configuration.
+
+## Installation
+
+Add to your `Cargo.toml`:
+
+```toml
+[dependencies]
+alpaca-http = "0.7.0"
+```
+
+## Usage
+
+```rust
+use alpaca_http::AlpacaHttpClient;
+use alpaca_base::auth::AlpacaCredentials;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let credentials = AlpacaCredentials::from_env()?;
+    let client = AlpacaHttpClient::new(credentials);
+
+    let account = client.get_account().await?;
+    println!("Account ID: {}", account.id);
+
+    Ok(())
+}
+```
+
+## API Reference
+
+### Main Types
+
+- `AlpacaHttpClient` - The primary entry point for making REST API calls.
+- `OrderParams` - Builder for order creation requests.
+- `HttpError` - HTTP-specific error wrapper.
+
+### Main Modules
+
+- `client` - Core HTTP client implementation.
+- `endpoints` - Request and response models for all supported endpoints.
+
+## Examples
+
+Check the `examples/` directory in the repository for detailed usage:
+- `trading_orders.rs` - Creating and managing orders.
+- `market_data.rs` - Fetching real-time and historical market data.
+
+## Changelog
+
+### v0.7.0 (latest)
+- Migrated to workspace structure.
+- Improved async ergonomics.
+- Added support for latest market data v2 endpoints.
+
+## License
+
+MIT

--- a/alpaca-http/src/endpoints.rs
+++ b/alpaca-http/src/endpoints.rs
@@ -1677,6 +1677,283 @@ impl AlpacaHttpClient {
     }
 }
 
+// ============================================================================
+// Enhanced Crypto Trading Endpoints
+// ============================================================================
+
+/// Response for crypto snapshots (multi-symbol).
+#[derive(Debug, Serialize, Deserialize)]
+pub struct MultiCryptoSnapshotsResponse {
+    /// Map of symbol to snapshot.
+    pub snapshots: std::collections::HashMap<String, CryptoSnapshot>,
+}
+
+/// Response for multi-symbol crypto bars.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct MultiCryptoBarsResponse {
+    /// Map of symbol to bars.
+    pub bars: std::collections::HashMap<String, Vec<CryptoBar>>,
+    /// Next page token.
+    pub next_page_token: Option<String>,
+}
+
+/// Response for latest crypto bars (multi-symbol).
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LatestCryptoBarsResponse {
+    /// Map of symbol to latest bar.
+    pub bars: std::collections::HashMap<String, CryptoBar>,
+}
+
+/// Response for latest crypto quotes (multi-symbol).
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LatestCryptoQuotesResponse {
+    /// Map of symbol to latest quote.
+    pub quotes: std::collections::HashMap<String, CryptoQuote>,
+}
+
+/// Response for latest crypto trades (multi-symbol).
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LatestCryptoTradesResponse {
+    /// Map of symbol to latest trade.
+    pub trades: std::collections::HashMap<String, CryptoTrade>,
+}
+
+/// Response for crypto orderbooks.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CryptoOrderbooksResponse {
+    /// Map of symbol to orderbook.
+    pub orderbooks: std::collections::HashMap<String, CryptoOrderbook>,
+}
+
+impl AlpacaHttpClient {
+    // ========================================================================
+    // Crypto Wallet Endpoints (Broker API)
+    // ========================================================================
+
+    /// List crypto wallets for an account.
+    ///
+    /// # Arguments
+    /// * `account_id` - The account ID
+    ///
+    /// # Returns
+    /// List of crypto wallets
+    pub async fn list_crypto_wallets(&self, account_id: &str) -> Result<Vec<BrokerCryptoWallet>> {
+        self.get(&format!("/v1/accounts/{}/wallets", account_id))
+            .await
+    }
+
+    /// Create a crypto wallet for an account.
+    ///
+    /// # Arguments
+    /// * `account_id` - The account ID
+    /// * `request` - Wallet creation request
+    ///
+    /// # Returns
+    /// The created wallet
+    pub async fn create_crypto_wallet(
+        &self,
+        account_id: &str,
+        request: &CreateCryptoWalletRequest,
+    ) -> Result<BrokerCryptoWallet> {
+        self.post(&format!("/v1/accounts/{}/wallets", account_id), request)
+            .await
+    }
+
+    /// Get a crypto wallet by asset.
+    ///
+    /// # Arguments
+    /// * `account_id` - The account ID
+    /// * `asset` - The asset symbol (e.g., BTC, ETH)
+    ///
+    /// # Returns
+    /// The crypto wallet
+    pub async fn get_crypto_wallet(
+        &self,
+        account_id: &str,
+        asset: &str,
+    ) -> Result<BrokerCryptoWallet> {
+        self.get(&format!("/v1/accounts/{}/wallets/{}", account_id, asset))
+            .await
+    }
+
+    /// List crypto wallet transfers.
+    ///
+    /// # Arguments
+    /// * `account_id` - The account ID
+    ///
+    /// # Returns
+    /// List of crypto transfers
+    pub async fn list_crypto_transfers(&self, account_id: &str) -> Result<Vec<CryptoTransfer>> {
+        self.get(&format!("/v1/accounts/{}/wallets/transfers", account_id))
+            .await
+    }
+
+    /// Create a crypto wallet transfer.
+    ///
+    /// # Arguments
+    /// * `account_id` - The account ID
+    /// * `asset` - The asset symbol
+    /// * `request` - Transfer request
+    ///
+    /// # Returns
+    /// The created transfer
+    pub async fn create_crypto_transfer(
+        &self,
+        account_id: &str,
+        asset: &str,
+        request: &CreateCryptoTransferRequest,
+    ) -> Result<CryptoTransfer> {
+        self.post(
+            &format!("/v1/accounts/{}/wallets/{}/transfers", account_id, asset),
+            request,
+        )
+        .await
+    }
+
+    /// List whitelisted crypto addresses.
+    ///
+    /// # Arguments
+    /// * `account_id` - The account ID
+    ///
+    /// # Returns
+    /// List of whitelisted addresses
+    pub async fn list_crypto_whitelists(
+        &self,
+        account_id: &str,
+    ) -> Result<Vec<CryptoWhitelistAddress>> {
+        self.get(&format!("/v1/accounts/{}/wallets/whitelists", account_id))
+            .await
+    }
+
+    /// Add a whitelisted crypto address.
+    ///
+    /// # Arguments
+    /// * `account_id` - The account ID
+    /// * `request` - Whitelist request
+    ///
+    /// # Returns
+    /// The created whitelist entry
+    pub async fn create_crypto_whitelist(
+        &self,
+        account_id: &str,
+        request: &CreateCryptoWhitelistRequest,
+    ) -> Result<CryptoWhitelistAddress> {
+        self.post(
+            &format!("/v1/accounts/{}/wallets/whitelists", account_id),
+            request,
+        )
+        .await
+    }
+
+    // ========================================================================
+    // Enhanced Crypto Market Data Endpoints
+    // ========================================================================
+
+    /// Get multi-symbol crypto bars.
+    ///
+    /// # Arguments
+    /// * `params` - Query parameters
+    ///
+    /// # Returns
+    /// Crypto bar data for multiple symbols
+    pub async fn get_multi_crypto_bars(
+        &self,
+        params: &CryptoBarsParams,
+    ) -> Result<MultiCryptoBarsResponse> {
+        self.get_with_params("/v1beta3/crypto/us/bars", params)
+            .await
+    }
+
+    /// Get latest crypto bars.
+    ///
+    /// # Arguments
+    /// * `symbols` - Comma-separated list of symbols
+    ///
+    /// # Returns
+    /// Latest bar for each symbol
+    pub async fn get_latest_crypto_bars(&self, symbols: &str) -> Result<LatestCryptoBarsResponse> {
+        #[derive(Serialize)]
+        struct Params<'a> {
+            symbols: &'a str,
+        }
+        self.get_with_params("/v1beta3/crypto/us/latest/bars", &Params { symbols })
+            .await
+    }
+
+    /// Get latest crypto quotes.
+    ///
+    /// # Arguments
+    /// * `symbols` - Comma-separated list of symbols
+    ///
+    /// # Returns
+    /// Latest quote for each symbol
+    pub async fn get_latest_crypto_quotes(
+        &self,
+        symbols: &str,
+    ) -> Result<LatestCryptoQuotesResponse> {
+        #[derive(Serialize)]
+        struct Params<'a> {
+            symbols: &'a str,
+        }
+        self.get_with_params("/v1beta3/crypto/us/latest/quotes", &Params { symbols })
+            .await
+    }
+
+    /// Get latest crypto trades.
+    ///
+    /// # Arguments
+    /// * `symbols` - Comma-separated list of symbols
+    ///
+    /// # Returns
+    /// Latest trade for each symbol
+    pub async fn get_latest_crypto_trades(
+        &self,
+        symbols: &str,
+    ) -> Result<LatestCryptoTradesResponse> {
+        #[derive(Serialize)]
+        struct Params<'a> {
+            symbols: &'a str,
+        }
+        self.get_with_params("/v1beta3/crypto/us/latest/trades", &Params { symbols })
+            .await
+    }
+
+    /// Get crypto snapshots for multiple symbols.
+    ///
+    /// # Arguments
+    /// * `symbols` - Comma-separated list of symbols
+    ///
+    /// # Returns
+    /// Snapshots for each symbol
+    pub async fn get_multi_crypto_snapshots(
+        &self,
+        symbols: &str,
+    ) -> Result<MultiCryptoSnapshotsResponse> {
+        #[derive(Serialize)]
+        struct Params<'a> {
+            symbols: &'a str,
+        }
+        self.get_with_params("/v1beta3/crypto/us/snapshots", &Params { symbols })
+            .await
+    }
+
+    /// Get crypto orderbooks.
+    ///
+    /// # Arguments
+    /// * `symbols` - Comma-separated list of symbols
+    ///
+    /// # Returns
+    /// Orderbooks for each symbol
+    pub async fn get_crypto_orderbooks(&self, symbols: &str) -> Result<CryptoOrderbooksResponse> {
+        #[derive(Serialize)]
+        struct Params<'a> {
+            symbols: &'a str,
+        }
+        self.get_with_params("/v1beta3/crypto/us/latest/orderbooks", &Params { symbols })
+            .await
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/alpaca-websocket/README.md
+++ b/alpaca-websocket/README.md
@@ -1,0 +1,78 @@
+# alpaca-websocket
+
+WebSocket client for the Alpaca trading platform real-time data and account updates.
+
+## Overview
+
+`alpaca-websocket` provides a robust, asynchronous interface for Alpaca's streaming APIs. It supports real-time market data (trades, quotes, bars) and account-related event streams (order updates, position changes).
+
+## Features
+
+- **Real-Time Market Data**: Subscribe to stock and crypto streams for sub-second updates.
+- **Account Updates**: Stream trading events to react instantly to order fills and cancellations.
+- **Automatic Reconnection**: Intelligent connection management with configurable retry logic.
+- **Multiple Stream Support**: Connect to Market Data v2 and Trading streams simultaneously.
+- **Type-Safe Messages**: Strongly typed representations for all WebSocket message types.
+
+## Installation
+
+Add to your `Cargo.toml`:
+
+```toml
+[dependencies]
+alpaca-websocket = "0.2.0"
+```
+
+## Usage
+
+```rust
+use alpaca_websocket::AlpacaWebSocketClient;
+use alpaca_base::auth::AlpacaCredentials;
+use alpaca_websocket::config::StreamType;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let credentials = AlpacaCredentials::from_env()?;
+    let mut client = AlpacaWebSocketClient::new(credentials, StreamType::MarketData);
+
+    client.connect().await?;
+    client.subscribe_trades(&["AAPL", "TSLA"]).await?;
+
+    while let Some(msg) = client.next_message().await? {
+        println!("Received: {:?}", msg);
+    }
+
+    Ok(())
+}
+```
+
+## API Reference
+
+### Main Types
+
+- `AlpacaWebSocketClient` - The primary client for managing WebSocket connections.
+- `WebSocketConfig` - Configuration options for timeouts and reconnection behavior.
+- `StreamType` - Enum specifying which Alpaca stream to connect to (MarketData or Trading).
+
+### Main Modules
+
+- `client` - WebSocket client implementation.
+- `messages` - Message types for all streaming data.
+- `streams` - Stream handling and subscription logic.
+
+## Examples
+
+See the `examples/` directory for detailed streaming usage:
+- `stream_market_data.rs` - Subscribing to trade and quote updates.
+- `stream_trade_updates.rs` - Listening for order execution events.
+
+## Changelog
+
+### v0.2.0 (latest)
+- Integrated into the workspace structure.
+- Improved subscription management.
+- Added support for enhanced Crypto Market Data.
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary

Implements Issue #8 - Enhanced Crypto Trading. This PR adds comprehensive support for crypto wallets, transfers, and enhanced market data.

## Changes

### Types (alpaca-base v0.9.0)
- `CryptoChain` enum: Btc, Eth, Sol, Avax, Matic, Arb, Base
- `CryptoTransferStatus` enum: Pending, Approved, PendingSend, Sent, Complete, Rejected, Failed
- `CryptoTransferDirection` enum: Incoming, Outgoing
- `CryptoWalletStatus` enum: Active, Inactive, Pending
- `BrokerCryptoWallet` struct for Broker API wallets
- `CryptoTransfer` struct and `CreateCryptoTransferRequest`
- `CryptoWhitelistAddress` and `CreateCryptoWhitelistRequest`
- `CryptoSnapshot`, `CryptoTrade`, `CryptoQuote`, `CryptoBar` structs
- `CryptoOrderbook` and `CryptoOrderbookEntry` structs
- `CryptoBarsParams` with builder pattern

### HTTP Endpoints (alpaca-http v0.8.0)
- `list_crypto_wallets()`, `create_crypto_wallet()`, `get_crypto_wallet()`
- `list_crypto_transfers()`, `create_crypto_transfer()`
- `list_crypto_whitelists()`, `create_crypto_whitelist()`
- `get_multi_crypto_bars()`, `get_latest_crypto_bars()`
- `get_latest_crypto_quotes()`, `get_latest_crypto_trades()`
- `get_multi_crypto_snapshots()`, `get_crypto_orderbooks()`

## Testing

- Unit tests: 81 tests (4 new for Crypto types)
- All tests pass: `make test`
- Linting passes: `make pre-push`

## Checklist

- [x] Version bumped (alpaca-base: 0.9.0, alpaca-http: 0.8.0)
- [x] Unit tests added (4 new tests)
- [x] `make pre-push` passes

Closes #8