### PR TITLE
feat(news): implement News API Enhancement

### DIFF
--- a/alpaca-base/Cargo.toml
+++ b/alpaca-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alpaca-base"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "Base library with common structs, traits, and logic for Alpaca API clients"

--- a/alpaca-http/Cargo.toml
+++ b/alpaca-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alpaca-http"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "HTTP REST API client for Alpaca trading platform"

--- a/alpaca-http/src/endpoints.rs
+++ b/alpaca-http/src/endpoints.rs
@@ -1954,6 +1954,64 @@ impl AlpacaHttpClient {
     }
 }
 
+// ============================================================================
+// News API Endpoints
+// ============================================================================
+
+/// Response for enhanced news request.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct EnhancedNewsResponse {
+    /// News articles.
+    pub news: Vec<EnhancedNewsArticle>,
+    /// Next page token.
+    pub next_page_token: Option<String>,
+}
+
+impl AlpacaHttpClient {
+    /// Get enhanced news articles with images and full content.
+    ///
+    /// # Arguments
+    /// * `params` - Query parameters for filtering news
+    ///
+    /// # Returns
+    /// List of enhanced news articles with pagination
+    pub async fn get_enhanced_news(
+        &self,
+        params: &alpaca_base::NewsParams,
+    ) -> Result<EnhancedNewsResponse> {
+        self.get_with_params("/v1beta1/news", params).await
+    }
+
+    /// Get enhanced news for specific symbols.
+    ///
+    /// # Arguments
+    /// * `symbols` - Comma-separated list of symbols
+    /// * `limit` - Maximum number of articles
+    ///
+    /// # Returns
+    /// List of enhanced news articles
+    pub async fn get_enhanced_news_for_symbols(
+        &self,
+        symbols: &str,
+        limit: u32,
+    ) -> Result<EnhancedNewsResponse> {
+        let params = alpaca_base::NewsParams::new().symbols(symbols).limit(limit);
+        self.get_enhanced_news(&params).await
+    }
+
+    /// Get latest enhanced news.
+    ///
+    /// # Arguments
+    /// * `limit` - Maximum number of articles
+    ///
+    /// # Returns
+    /// List of latest enhanced news articles
+    pub async fn get_latest_enhanced_news(&self, limit: u32) -> Result<EnhancedNewsResponse> {
+        let params = alpaca_base::NewsParams::new().sort_desc().limit(limit);
+        self.get_enhanced_news(&params).await
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

Implements Issue #10 - News API Enhancement. This PR adds comprehensive support for enhanced news articles with images and full content.

## Changes

### Types (alpaca-base v0.10.0)
- `NewsContentType` enum: Article, Video, Audio
- `NewsImageSize` enum: Thumb, Small, Large
- `NewsImage` struct
- `NewsSource` struct
- `EnhancedNewsArticle` struct with images and full content
- `NewsParams` with builder pattern for filtering

### HTTP Endpoints (alpaca-http v0.9.0)
- `get_enhanced_news()` - Get news with full filtering
- `get_enhanced_news_for_symbols()` - Get news for specific symbols
- `get_latest_enhanced_news()` - Get latest news

## Testing

- Unit tests: 83 tests (2 new for News API types)
- All tests pass: `make test`
- Linting passes: `make pre-push`

## Checklist

- [x] Version bumped (alpaca-base: 0.10.0, alpaca-http: 0.9.0)
- [x] Unit tests added (2 new tests)
- [x] `make pre-push` passes

Closes #10