### PR TITLE
feat(oauth): implement OAuth 2.0 Support

### DIFF
--- a/alpaca-base/Cargo.toml
+++ b/alpaca-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alpaca-base"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "Base library with common structs, traits, and logic for Alpaca API clients"

--- a/alpaca-base/src/auth.rs
+++ b/alpaca-base/src/auth.rs
@@ -87,21 +87,33 @@ impl Credentials {
 }
 
 /// OAuth token for API access.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct OAuthToken {
     /// The access token string.
     pub access_token: String,
+    /// Refresh token for obtaining new access tokens.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refresh_token: Option<String>,
     /// The token type (e.g., "Bearer").
     pub token_type: String,
     /// Token expiration time in seconds.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub expires_in: Option<u64>,
     /// OAuth scope granted.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub scope: Option<String>,
 }
 
 impl OAuthToken {
-    /// Create authorization header from OAuth token
+    /// Create authorization header from OAuth token.
+    #[must_use]
     pub fn auth_header(&self) -> String {
         format!("{} {}", self.token_type, self.access_token)
+    }
+
+    /// Check if token has a refresh token.
+    #[must_use]
+    pub fn has_refresh_token(&self) -> bool {
+        self.refresh_token.is_some()
     }
 }

--- a/alpaca-http/Cargo.toml
+++ b/alpaca-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alpaca-http"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "HTTP REST API client for Alpaca trading platform"

--- a/alpaca-http/src/endpoints.rs
+++ b/alpaca-http/src/endpoints.rs
@@ -7,7 +7,7 @@
 #![allow(missing_docs)]
 
 use crate::client::AlpacaHttpClient;
-use alpaca_base::{Result, types::*};
+use alpaca_base::{OAuthToken, Result, types::*};
 use chrono::{DateTime, NaiveDate, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -2009,6 +2009,43 @@ impl AlpacaHttpClient {
     pub async fn get_latest_enhanced_news(&self, limit: u32) -> Result<EnhancedNewsResponse> {
         let params = alpaca_base::NewsParams::new().sort_desc().limit(limit);
         self.get_enhanced_news(&params).await
+    }
+}
+
+// ============================================================================
+// OAuth 2.0 Endpoints
+// ============================================================================
+
+impl AlpacaHttpClient {
+    /// Exchange authorization code for OAuth token.
+    ///
+    /// # Arguments
+    /// * `request` - Token exchange request
+    ///
+    /// # Returns
+    /// OAuth token
+    pub async fn oauth_exchange_code(&self, request: &OAuthTokenRequest) -> Result<OAuthToken> {
+        self.post("/oauth/token", request).await
+    }
+
+    /// Refresh OAuth token.
+    ///
+    /// # Arguments
+    /// * `request` - Token refresh request
+    ///
+    /// # Returns
+    /// New OAuth token
+    pub async fn oauth_refresh_token(&self, request: &OAuthTokenRequest) -> Result<OAuthToken> {
+        self.post("/oauth/token", request).await
+    }
+
+    /// Revoke OAuth token.
+    ///
+    /// # Arguments
+    /// * `request` - Token revoke request
+    pub async fn oauth_revoke_token(&self, request: &OAuthRevokeRequest) -> Result<()> {
+        let _: serde_json::Value = self.post("/oauth/revoke", request).await?;
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Summary

Implements Issue #8 - OAuth 2.0 Support. This PR adds comprehensive OAuth 2.0 authentication flow for third-party applications.

## Changes

### Types (alpaca-base v0.11.0)
- `OAuthScope` enum: AccountWrite, Trading, Data
- `OAuthConfig` struct with builder pattern for configuration
- `OAuthTokenRequest` for code exchange and refresh
- `OAuthRevokeRequest` for token revocation
- Enhanced `OAuthToken` with refresh_token and Serialize/Deserialize

### HTTP Endpoints (alpaca-http v0.10.0)
- `oauth_exchange_code()` - Exchange authorization code for token
- `oauth_refresh_token()` - Refresh OAuth token
- `oauth_revoke_token()` - Revoke OAuth token

### Features
- Authorization URL generation
- Scope management
- Token refresh support

## Testing

- Unit tests: 86 tests (3 new for OAuth types)
- All tests pass: `make test`
- Linting passes: `make pre-push`

## Checklist

- [x] Version bumped (alpaca-base: 0.11.0, alpaca-http: 0.10.0)
- [x] Unit tests added (3 new tests)
- [x] `make pre-push` passes

Closes #8