### PR TITLE
feat(activities): implement Enhanced Account Activities

### DIFF
--- a/alpaca-base/Cargo.toml
+++ b/alpaca-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alpaca-base"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "Base library with common structs, traits, and logic for Alpaca API clients"

--- a/alpaca-base/src/types.rs
+++ b/alpaca-base/src/types.rs
@@ -3700,6 +3700,145 @@ impl ListAnnouncementsParams {
     }
 }
 
+// ============================================================================
+// Enhanced Account Activities Types
+// ============================================================================
+
+/// Trade activity with detailed fields.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct TradeActivity {
+    /// Activity ID.
+    pub id: String,
+    /// Activity type.
+    pub activity_type: ActivityType,
+    /// Transaction time.
+    pub transaction_time: DateTime<Utc>,
+    /// Symbol.
+    pub symbol: String,
+    /// Order ID.
+    pub order_id: Uuid,
+    /// Side.
+    pub side: OrderSide,
+    /// Quantity.
+    pub qty: String,
+    /// Price.
+    pub price: String,
+    /// Cumulative quantity.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cum_qty: Option<String>,
+    /// Leaves quantity.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub leaves_qty: Option<String>,
+}
+
+/// Non-trade activity with detailed fields.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct NonTradeActivity {
+    /// Activity ID.
+    pub id: String,
+    /// Activity type.
+    pub activity_type: ActivityType,
+    /// Date.
+    pub date: String,
+    /// Net amount.
+    pub net_amount: String,
+    /// Symbol (if applicable).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub symbol: Option<String>,
+    /// Quantity (if applicable).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub qty: Option<String>,
+    /// Per share amount.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub per_share_amount: Option<String>,
+    /// Description.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+/// Parameters for listing account activities.
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+pub struct ListActivitiesParams {
+    /// Filter by activity types (comma-separated).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub activity_types: Option<String>,
+    /// Filter by date.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub date: Option<String>,
+    /// Filter until date.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub until: Option<String>,
+    /// Filter after date.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub after: Option<String>,
+    /// Sort direction.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub direction: Option<SortDirection>,
+    /// Page size.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub page_size: Option<u32>,
+    /// Page token.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub page_token: Option<String>,
+}
+
+impl ListActivitiesParams {
+    /// Create new empty parameters.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Filter by activity types.
+    #[must_use]
+    pub fn activity_types(mut self, types: &str) -> Self {
+        self.activity_types = Some(types.to_string());
+        self
+    }
+
+    /// Filter by date.
+    #[must_use]
+    pub fn date(mut self, date: &str) -> Self {
+        self.date = Some(date.to_string());
+        self
+    }
+
+    /// Filter until date.
+    #[must_use]
+    pub fn until(mut self, until: &str) -> Self {
+        self.until = Some(until.to_string());
+        self
+    }
+
+    /// Filter after date.
+    #[must_use]
+    pub fn after(mut self, after: &str) -> Self {
+        self.after = Some(after.to_string());
+        self
+    }
+
+    /// Set sort direction.
+    #[must_use]
+    pub fn direction(mut self, direction: SortDirection) -> Self {
+        self.direction = Some(direction);
+        self
+    }
+
+    /// Set page size.
+    #[must_use]
+    pub fn page_size(mut self, size: u32) -> Self {
+        self.page_size = Some(size);
+        self
+    }
+
+    /// Set page token.
+    #[must_use]
+    pub fn page_token(mut self, token: &str) -> Self {
+        self.page_token = Some(token.to_string());
+        self
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -4150,5 +4289,28 @@ mod tests {
         assert_eq!(params.status, Some(AssetStatus::Active));
         assert_eq!(params.asset_class, Some("us_equity".to_string()));
         assert_eq!(params.exchange, Some("NYSE".to_string()));
+    }
+
+    #[test]
+    fn test_activity_type_serialization() {
+        let activity = ActivityType::Fill;
+        let json = serde_json::to_string(&activity).unwrap();
+        assert_eq!(json, "\"FILL\"");
+
+        let div = ActivityType::Div;
+        let json = serde_json::to_string(&div).unwrap();
+        assert_eq!(json, "\"DIV\"");
+    }
+
+    #[test]
+    fn test_list_activities_params_builder() {
+        let params = ListActivitiesParams::new()
+            .activity_types("FILL,DIV")
+            .direction(SortDirection::Desc)
+            .page_size(100);
+
+        assert_eq!(params.activity_types, Some("FILL,DIV".to_string()));
+        assert_eq!(params.direction, Some(SortDirection::Desc));
+        assert_eq!(params.page_size, Some(100));
     }
 }

--- a/alpaca-http/Cargo.toml
+++ b/alpaca-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alpaca-http"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "HTTP REST API client for Alpaca trading platform"

--- a/alpaca-http/src/endpoints.rs
+++ b/alpaca-http/src/endpoints.rs
@@ -2228,6 +2228,75 @@ impl AlpacaHttpClient {
     }
 }
 
+// ============================================================================
+// Enhanced Account Activities Endpoints
+// ============================================================================
+
+impl AlpacaHttpClient {
+    /// List account activities with filtering.
+    ///
+    /// # Arguments
+    /// * `params` - Query parameters for filtering
+    ///
+    /// # Returns
+    /// List of account activities
+    pub async fn list_activities(
+        &self,
+        params: &ListActivitiesParams,
+    ) -> Result<Vec<AccountActivity>> {
+        self.get_with_params("/v2/account/activities", params).await
+    }
+
+    /// List account activities by type.
+    ///
+    /// # Arguments
+    /// * `activity_type` - Activity type to filter by
+    /// * `params` - Additional query parameters
+    ///
+    /// # Returns
+    /// List of account activities
+    pub async fn list_activities_by_type(
+        &self,
+        activity_type: &str,
+        params: &ListActivitiesParams,
+    ) -> Result<Vec<AccountActivity>> {
+        self.get_with_params(&format!("/v2/account/activities/{}", activity_type), params)
+            .await
+    }
+
+    /// List all broker accounts activities.
+    ///
+    /// # Arguments
+    /// * `params` - Query parameters for filtering
+    ///
+    /// # Returns
+    /// List of account activities across all accounts
+    pub async fn list_broker_activities(
+        &self,
+        params: &ListActivitiesParams,
+    ) -> Result<Vec<AccountActivity>> {
+        self.get_with_params("/v1/accounts/activities", params)
+            .await
+    }
+
+    /// List activities for a specific broker account.
+    ///
+    /// # Arguments
+    /// * `account_id` - Account ID
+    /// * `params` - Query parameters for filtering
+    ///
+    /// # Returns
+    /// List of account activities
+    pub async fn list_broker_account_activities(
+        &self,
+        account_id: &str,
+        params: &ListActivitiesParams,
+    ) -> Result<Vec<AccountActivity>> {
+        self.get_with_params(&format!("/v1/accounts/{}/activities", account_id), params)
+            .await
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

Implements Issue #10 - Enhanced Account Activities. This PR adds comprehensive support for account activities with proper filtering and pagination.

## Changes

### Types (alpaca-base v0.14.0)
- `TradeActivity` struct with detailed trade fields (transaction_time, order_id, side, qty, price, cum_qty, leaves_qty)
- `NonTradeActivity` struct with detailed non-trade fields (date, net_amount, symbol, qty, per_share_amount, description)
- `ListActivitiesParams` with builder pattern for filtering (activity_types, date, until, after, direction, page_size, page_token)

### HTTP Endpoints (alpaca-http v0.13.0)
- `list_activities()` - List account activities with filtering
- `list_activities_by_type()` - List activities by specific type
- `list_broker_activities()` - List all broker accounts activities
- `list_broker_account_activities()` - List activities for specific account

## Testing

- Unit tests: 92 tests (2 new for Activities types)
- All tests pass: `make test`
- Linting passes: `make pre-push`

## Checklist

- [x] Version bumped (alpaca-base: 0.14.0, alpaca-http: 0.13.0)
- [x] Unit tests added (2 new tests)
- [x] `make pre-push` passes

Closes #10