### PR TITLE
feat(ratelimit): implement Rate Limiting types

### DIFF
--- a/alpaca-base/Cargo.toml
+++ b/alpaca-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alpaca-base"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "Base library with common structs, traits, and logic for Alpaca API clients"


### PR DESCRIPTION
## Summary

Implements Issue #16 - Rate Limiting and Request Management. This PR adds comprehensive rate limiting types for API throttling awareness.

## Changes

### Types (alpaca-base v0.16.0)
- `RateLimitConfig` struct with builder pattern (requests_per_minute, burst_limit, retry_on_rate_limit, max_retries, base_delay_ms)
- `RateLimitStatus` struct for tracking rate limits from headers (remaining, limit, reset_at)
- `RequestPriority` enum: Low, Normal, High, Critical

### Features
- Configurable requests per minute and burst limit
- Rate limit status tracking from response headers
- Priority levels for request queue management
- Helper methods: is_rate_limited(), seconds_until_reset()

## Testing

- Unit tests: 96 tests (2 new for Rate Limiting types)
- All tests pass: `make test`
- Linting passes: `make pre-push`

## Checklist

- [x] Version bumped (alpaca-base: 0.16.0)
- [x] Unit tests added (2 new tests)
- [x] `make pre-push` passes

Closes #16