### PR TITLE
feat(margin): implement Margin and Short Selling Support

### DIFF
--- a/alpaca-base/Cargo.toml
+++ b/alpaca-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alpaca-base"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "Base library with common structs, traits, and logic for Alpaca API clients"

--- a/alpaca-http/Cargo.toml
+++ b/alpaca-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alpaca-http"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "HTTP REST API client for Alpaca trading platform"

--- a/alpaca-http/src/endpoints.rs
+++ b/alpaca-http/src/endpoints.rs
@@ -2367,6 +2367,31 @@ impl AlpacaHttpClient {
     }
 }
 
+// ============================================================================
+// Margin and Short Selling Endpoints
+// ============================================================================
+
+impl AlpacaHttpClient {
+    /// Get locate availability for short selling.
+    ///
+    /// # Returns
+    /// List of available locates
+    pub async fn get_locates(&self) -> Result<Vec<LocateResponse>> {
+        self.get("/v1/locate/stocks").await
+    }
+
+    /// Request a locate for short selling.
+    ///
+    /// # Arguments
+    /// * `request` - Locate request
+    ///
+    /// # Returns
+    /// Locate response
+    pub async fn request_locate(&self, request: &LocateRequest) -> Result<LocateResponse> {
+        self.post("/v1/locate/stocks", request).await
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

Implements Issue #21 - Margin and Short Selling Support. This PR adds comprehensive margin trading and short selling types.

## Changes

### Types (alpaca-base v0.17.0)
- `MarginInfo` struct with all margin fields (buying_power, regt_buying_power, daytrading_buying_power, etc.)
- `ShortPosition` struct for short positions
- `BorrowRate` struct for borrow rate info
- `MarginRequirement` struct with calculation helpers
- `LocateRequest` and `LocateResponse` for short locates
- `PdtStatus` enum: No, Yes, Pending
- `BuyingPowerCalculator` with calculation helpers

### HTTP Endpoints (alpaca-http v0.15.0)
- `get_locates()` - Get locate availability
- `request_locate()` - Request a locate for short selling

## Testing

- Unit tests: 98 tests (2 new for Margin types)
- All tests pass: `make test`
- Linting passes: `make pre-push`

## Checklist

- [x] Version bumped (alpaca-base: 0.17.0, alpaca-http: 0.15.0)
- [x] Unit tests added (2 new tests)
- [x] `make pre-push` passes

Closes #21