### PR TITLE
feat(fix): implement FIX Protocol Support

### DIFF
--- a/alpaca-base/Cargo.toml
+++ b/alpaca-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alpaca-base"
-version = "0.20.0"
+version = "0.21.0"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "Base library with common structs, traits, and logic for Alpaca API clients"


### PR DESCRIPTION
## Summary

Implements Issue #19 - FIX Protocol Support. This PR adds FIX protocol types for high-frequency trading.

## Changes

### Types (alpaca-base v0.21.0)
- `FixVersion` enum: Fix42, Fix44
- `FixSessionConfig` struct with builder pattern
- `FixMsgType` enum for message types (Heartbeat, Logon, NewOrderSingle, etc.)
- `FixSessionState` enum: Disconnected, Connecting, LoggedOn, LoggingOut
- `FixSequenceNumbers` for sequence management

### Features
- FIX version configuration
- Session configuration (CompID, host, port)
- Message type tag values
- Sequence number management

## Testing

- Unit tests: 106 tests (2 new for FIX types)
- All tests pass: `make test`
- Linting passes: `make pre-push`

## Checklist

- [x] Version bumped (alpaca-base: 0.21.0)
- [x] Unit tests added (2 new tests)
- [x] `make pre-push` passes

Closes #19