### PR TITLE
feat(statements): implement Statements and Confirmations Support

### DIFF
--- a/alpaca-base/Cargo.toml
+++ b/alpaca-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alpaca-base"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "Base library with common structs, traits, and logic for Alpaca API clients"

--- a/alpaca-http/Cargo.toml
+++ b/alpaca-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alpaca-http"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "HTTP REST API client for Alpaca trading platform"


### PR DESCRIPTION
## Summary

Implements Issue #20 - Statements and Confirmations Support. This PR adds types for account statements, trade confirmations, and tax documents.

## Changes

### Types (alpaca-base v0.22.0)
- `StatementType` enum: AccountStatement, TradeConfirmation, TaxDocument
- `TaxFormType` enum: Form1099B, Form1099Div, Form1099Int
- `AccountDocument` struct
- `TradeConfirmation` struct
- `TaxDocument` struct
- `DocumentParams` builder

### Features
- Document type filtering
- Date range queries
- Tax form types

## Testing

- Unit tests: 107 tests (1 new for Document types)
- All tests pass: `make test`
- Linting passes: `make pre-push`

## Checklist

- [x] Version bumped (alpaca-base: 0.22.0, alpaca-http: 0.18.0)
- [x] Unit tests added (1 new test)
- [x] `make pre-push` passes

Closes #20