### PR TITLE
feat(lct): implement Local Currency Trading Support

### DIFF
--- a/alpaca-base/Cargo.toml
+++ b/alpaca-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alpaca-base"
-version = "0.22.0"
+version = "0.23.0"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "Base library with common structs, traits, and logic for Alpaca API clients"

--- a/alpaca-http/Cargo.toml
+++ b/alpaca-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alpaca-http"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "HTTP REST API client for Alpaca trading platform"

--- a/alpaca-http/src/endpoints.rs
+++ b/alpaca-http/src/endpoints.rs
@@ -2406,6 +2406,31 @@ impl AlpacaHttpClient {
     }
 }
 
+// ============================================================================
+// Local Currency Trading Endpoints
+// ============================================================================
+
+impl AlpacaHttpClient {
+    /// Get exchange rates.
+    ///
+    /// # Returns
+    /// List of exchange rates
+    pub async fn get_exchange_rates(&self) -> Result<Vec<ExchangeRate>> {
+        self.get("/v1/fx/rates").await
+    }
+
+    /// Get specific exchange rate.
+    ///
+    /// # Arguments
+    /// * `currency_pair` - Currency pair (e.g., "EUR/USD")
+    ///
+    /// # Returns
+    /// Exchange rate
+    pub async fn get_exchange_rate(&self, currency_pair: &str) -> Result<ExchangeRate> {
+        self.get(&format!("/v1/fx/rates/{}", currency_pair)).await
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

Implements Issue #24 - Local Currency Trading Support. This PR adds types for international currency trading.

## Changes

### Types (alpaca-base v0.23.0)
- `Currency` enum: USD, EUR, GBP, CAD, AUD, JPY, CHF
- `ExchangeRate` struct with conversion methods
- `CurrencyPair` struct
- `LctPosition` struct for local currency positions

### HTTP Endpoints (alpaca-http v0.19.0)
- `get_exchange_rates()` - Get all exchange rates
- `get_exchange_rate()` - Get specific rate by pair

### Features
- Currency conversion utilities
- Inverse rate calculation
- Currency pair formatting

## Testing

- Unit tests: 109 tests (2 new for LCT types)
- All tests pass: `make test`
- Linting passes: `make pre-push`

## Checklist

- [x] Version bumped (alpaca-base: 0.23.0, alpaca-http: 0.19.0)
- [x] Unit tests added (2 new tests)
- [x] `make pre-push` passes

Closes #24