### PR TITLE
feat(ira): implement IRA Account Support

### DIFF
--- a/alpaca-base/Cargo.toml
+++ b/alpaca-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alpaca-base"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "Base library with common structs, traits, and logic for Alpaca API clients"

--- a/alpaca-base/src/types.rs
+++ b/alpaca-base/src/types.rs
@@ -5323,6 +5323,141 @@ pub struct LctPosition {
     pub currency: Currency,
 }
 
+// ============================================================================
+// IRA Account Types
+// ============================================================================
+
+/// IRA account type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IraAccountType {
+    /// Traditional IRA.
+    Traditional,
+    /// Roth IRA.
+    Roth,
+    /// SEP IRA (Simplified Employee Pension).
+    Sep,
+    /// SIMPLE IRA (Savings Incentive Match Plan for Employees).
+    Simple,
+}
+
+impl std::fmt::Display for IraAccountType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Traditional => write!(f, "Traditional"),
+            Self::Roth => write!(f, "Roth"),
+            Self::Sep => write!(f, "SEP"),
+            Self::Simple => write!(f, "SIMPLE"),
+        }
+    }
+}
+
+/// IRA contribution.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct IraContribution {
+    /// Contribution ID.
+    pub id: String,
+    /// Account ID.
+    pub account_id: String,
+    /// Contribution amount.
+    pub amount: String,
+    /// Tax year.
+    pub tax_year: u16,
+    /// Contribution date.
+    pub date: String,
+    /// Contribution type (regular, rollover, etc.).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contribution_type: Option<String>,
+}
+
+/// IRA distribution.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct IraDistribution {
+    /// Distribution ID.
+    pub id: String,
+    /// Account ID.
+    pub account_id: String,
+    /// Distribution amount.
+    pub amount: String,
+    /// Distribution date.
+    pub date: String,
+    /// Distribution reason.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    /// Federal withholding amount.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub federal_withholding: Option<String>,
+    /// State withholding amount.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state_withholding: Option<String>,
+}
+
+/// IRA beneficiary.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct IraBeneficiary {
+    /// Beneficiary ID.
+    pub id: String,
+    /// Account ID.
+    pub account_id: String,
+    /// Beneficiary name.
+    pub name: String,
+    /// Beneficiary type (primary, contingent).
+    pub beneficiary_type: String,
+    /// Percentage share.
+    pub percentage: f64,
+    /// Relationship to account holder.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub relationship: Option<String>,
+}
+
+/// IRA contribution request.
+#[derive(Debug, Serialize, Clone)]
+pub struct CreateIraContributionRequest {
+    /// Contribution amount.
+    pub amount: String,
+    /// Tax year.
+    pub tax_year: u16,
+}
+
+impl CreateIraContributionRequest {
+    /// Create new contribution request.
+    #[must_use]
+    pub fn new(amount: &str, tax_year: u16) -> Self {
+        Self {
+            amount: amount.to_string(),
+            tax_year,
+        }
+    }
+}
+
+/// IRA distribution request.
+#[derive(Debug, Serialize, Clone)]
+pub struct CreateIraDistributionRequest {
+    /// Distribution amount.
+    pub amount: String,
+    /// Distribution reason.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+impl CreateIraDistributionRequest {
+    /// Create new distribution request.
+    #[must_use]
+    pub fn new(amount: &str) -> Self {
+        Self {
+            amount: amount.to_string(),
+            reason: None,
+        }
+    }
+
+    /// Set distribution reason.
+    #[must_use]
+    pub fn reason(mut self, reason: &str) -> Self {
+        self.reason = Some(reason.to_string());
+        self
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -5975,5 +6110,20 @@ mod tests {
     fn test_currency_pair() {
         let pair = CurrencyPair::new(Currency::Eur, Currency::Usd);
         assert_eq!(pair.as_string(), "EUR/USD");
+    }
+
+    #[test]
+    fn test_ira_account_type_display() {
+        assert_eq!(IraAccountType::Traditional.to_string(), "Traditional");
+        assert_eq!(IraAccountType::Roth.to_string(), "Roth");
+        assert_eq!(IraAccountType::Sep.to_string(), "SEP");
+        assert_eq!(IraAccountType::Simple.to_string(), "SIMPLE");
+    }
+
+    #[test]
+    fn test_create_ira_contribution_request() {
+        let req = CreateIraContributionRequest::new("5000.00", 2024);
+        assert_eq!(req.amount, "5000.00");
+        assert_eq!(req.tax_year, 2024);
     }
 }

--- a/alpaca-http/Cargo.toml
+++ b/alpaca-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alpaca-http"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "HTTP REST API client for Alpaca trading platform"

--- a/alpaca-http/src/endpoints.rs
+++ b/alpaca-http/src/endpoints.rs
@@ -2431,6 +2431,68 @@ impl AlpacaHttpClient {
     }
 }
 
+// ============================================================================
+// IRA Account Endpoints
+// ============================================================================
+
+impl AlpacaHttpClient {
+    /// List IRA contributions.
+    ///
+    /// # Arguments
+    /// * `account_id` - Account ID
+    ///
+    /// # Returns
+    /// List of IRA contributions
+    pub async fn list_ira_contributions(&self, account_id: &str) -> Result<Vec<IraContribution>> {
+        self.get(&format!("/v1/accounts/{}/ira/contributions", account_id))
+            .await
+    }
+
+    /// Create IRA contribution.
+    ///
+    /// # Arguments
+    /// * `account_id` - Account ID
+    /// * `request` - Contribution request
+    ///
+    /// # Returns
+    /// Created contribution
+    pub async fn create_ira_contribution(
+        &self,
+        account_id: &str,
+        request: &CreateIraContributionRequest,
+    ) -> Result<IraContribution> {
+        self.post(
+            &format!("/v1/accounts/{}/ira/contributions", account_id),
+            request,
+        )
+        .await
+    }
+
+    /// List IRA distributions.
+    ///
+    /// # Arguments
+    /// * `account_id` - Account ID
+    ///
+    /// # Returns
+    /// List of IRA distributions
+    pub async fn list_ira_distributions(&self, account_id: &str) -> Result<Vec<IraDistribution>> {
+        self.get(&format!("/v1/accounts/{}/ira/distributions", account_id))
+            .await
+    }
+
+    /// List IRA beneficiaries.
+    ///
+    /// # Arguments
+    /// * `account_id` - Account ID
+    ///
+    /// # Returns
+    /// List of IRA beneficiaries
+    pub async fn list_ira_beneficiaries(&self, account_id: &str) -> Result<Vec<IraBeneficiary>> {
+        self.get(&format!("/v1/accounts/{}/ira/beneficiaries", account_id))
+            .await
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

Implements Issue #25 - IRA Account Support. This PR adds types for Individual Retirement Accounts.

## Changes

### Types (alpaca-base v0.24.0)
- `IraAccountType` enum: Traditional, Roth, Sep, Simple
- `IraContribution` struct
- `IraDistribution` struct
- `IraBeneficiary` struct
- `CreateIraContributionRequest`
- `CreateIraDistributionRequest`

### HTTP Endpoints (alpaca-http v0.20.0)
- `list_ira_contributions()` - List contributions
- `create_ira_contribution()` - Create contribution
- `list_ira_distributions()` - List distributions
- `list_ira_beneficiaries()` - List beneficiaries

## Testing

- Unit tests: 111 tests (2 new for IRA types)
- All tests pass: `make test`
- Linting passes: `make pre-push`

## Checklist

- [x] Version bumped (alpaca-base: 0.24.0, alpaca-http: 0.20.0)
- [x] Unit tests added (2 new tests)
- [x] `make pre-push` passes

Closes #25