### PR TITLE
feat(examples): implement FIX Protocol examples (E006)

### DIFF
--- a/alpaca-fix/README.md
+++ b/alpaca-fix/README.md
@@ -31,6 +31,28 @@ Add to your `Cargo.toml`:
 alpaca-fix = "0.2.0"
 ```
 
+## Examples
+
+Run examples with `cargo run -p alpaca-fix --example <name>`:
+
+| Example | Description |
+|---------|-------------|
+| `fix_session_setup` | Configure and set up a FIX session |
+| `fix_new_order_single` | Create New Order Single messages |
+| `fix_order_cancel` | Create Cancel and Cancel/Replace messages |
+| `fix_execution_report` | Execution Report message structure |
+| `fix_market_data_request` | Market Data Request messages |
+
+```bash
+# Session setup example
+cargo run -p alpaca-fix --example fix_session_setup
+
+# New Order Single example
+cargo run -p alpaca-fix --example fix_new_order_single
+```
+
+**Note**: FIX protocol requires special access from Alpaca. Contact Alpaca support to enable FIX access for your account.
+
 ## Contribution and Contact
 
 We welcome contributions to this project! If you would like to contribute, please follow these steps:

--- a/alpaca-fix/examples/fix_execution_report.rs
+++ b/alpaca-fix/examples/fix_execution_report.rs
@@ -1,0 +1,161 @@
+//! # FIX Execution Report
+//!
+//! This example demonstrates FIX Execution Report message structure and parsing.
+//!
+//! ## Prerequisites
+//!
+//! Set environment variables:
+//! - `ALPACA_API_KEY`: Your Alpaca API key
+//! - `ALPACA_API_SECRET`: Your Alpaca secret key
+//!
+//! ## Usage
+//!
+//! ```bash
+//! cargo run -p alpaca-fix --example fix_execution_report
+//! ```
+//!
+//! **Note**: This example demonstrates message structures.
+//! FIX protocol requires special access from Alpaca.
+
+use alpaca_fix::{ExecType, ExecutionReport, OrdStatus, Side};
+
+fn main() {
+    println!("=== FIX Execution Report ===\n");
+
+    // Simulate an execution report for a new order
+    println!("--- New Order Execution Report ---");
+    let new_order_report = ExecutionReport {
+        order_id: "alpaca-order-123".to_string(),
+        cl_ord_id: "client-order-456".to_string(),
+        exec_id: "exec-789".to_string(),
+        exec_type: ExecType::New,
+        ord_status: OrdStatus::New,
+        symbol: "AAPL".to_string(),
+        side: Side::Buy,
+        order_qty: 100.0,
+        last_qty: None,
+        last_px: None,
+        cum_qty: 0.0,
+        avg_px: 0.0,
+        leaves_qty: 100.0,
+        text: None,
+    };
+
+    print_execution_report(&new_order_report);
+
+    // Simulate a partial fill
+    println!("\n--- Partial Fill Execution Report ---");
+    let partial_fill = ExecutionReport {
+        order_id: "alpaca-order-123".to_string(),
+        cl_ord_id: "client-order-456".to_string(),
+        exec_id: "exec-790".to_string(),
+        exec_type: ExecType::PartialFill,
+        ord_status: OrdStatus::PartiallyFilled,
+        symbol: "AAPL".to_string(),
+        side: Side::Buy,
+        order_qty: 100.0,
+        last_qty: Some(50.0),
+        last_px: Some(175.50),
+        cum_qty: 50.0,
+        avg_px: 175.50,
+        leaves_qty: 50.0,
+        text: None,
+    };
+
+    print_execution_report(&partial_fill);
+
+    // Simulate a full fill
+    println!("\n--- Full Fill Execution Report ---");
+    let full_fill = ExecutionReport {
+        order_id: "alpaca-order-123".to_string(),
+        cl_ord_id: "client-order-456".to_string(),
+        exec_id: "exec-791".to_string(),
+        exec_type: ExecType::Fill,
+        ord_status: OrdStatus::Filled,
+        symbol: "AAPL".to_string(),
+        side: Side::Buy,
+        order_qty: 100.0,
+        last_qty: Some(50.0),
+        last_px: Some(175.55),
+        cum_qty: 100.0,
+        avg_px: 175.525,
+        leaves_qty: 0.0,
+        text: None,
+    };
+
+    print_execution_report(&full_fill);
+
+    // Simulate a rejection
+    println!("\n--- Rejected Order Execution Report ---");
+    let rejected = ExecutionReport {
+        order_id: "alpaca-order-999".to_string(),
+        cl_ord_id: "client-order-999".to_string(),
+        exec_id: "exec-999".to_string(),
+        exec_type: ExecType::Rejected,
+        ord_status: OrdStatus::Rejected,
+        symbol: "INVALID".to_string(),
+        side: Side::Buy,
+        order_qty: 100.0,
+        last_qty: None,
+        last_px: None,
+        cum_qty: 0.0,
+        avg_px: 0.0,
+        leaves_qty: 0.0,
+        text: Some("Unknown symbol".to_string()),
+    };
+
+    print_execution_report(&rejected);
+
+    // Execution type reference
+    println!("\n--- Execution Types (Tag 150) ---");
+    println!("  0 = New");
+    println!("  1 = Partial Fill");
+    println!("  2 = Fill");
+    println!("  4 = Canceled");
+    println!("  5 = Replaced");
+    println!("  6 = Pending Cancel");
+    println!("  8 = Rejected");
+    println!("  A = Pending New");
+    println!("  C = Expired");
+
+    // Order status reference
+    println!("\n--- Order Status (Tag 39) ---");
+    println!("  0 = New");
+    println!("  1 = Partially Filled");
+    println!("  2 = Filled");
+    println!("  4 = Canceled");
+    println!("  8 = Rejected");
+
+    println!("\n=== Example Complete ===");
+}
+
+fn print_execution_report(report: &ExecutionReport) {
+    println!("  Order ID: {}", report.order_id);
+    println!("  Client Order ID: {}", report.cl_ord_id);
+    println!("  Exec ID: {}", report.exec_id);
+    println!(
+        "  Exec Type: {:?} ({})",
+        report.exec_type,
+        report.exec_type.as_char()
+    );
+    println!(
+        "  Order Status: {:?} ({})",
+        report.ord_status,
+        report.ord_status.as_char()
+    );
+    println!("  Symbol: {}", report.symbol);
+    println!("  Side: {:?}", report.side);
+    println!("  Order Qty: {}", report.order_qty);
+    if let Some(last_qty) = report.last_qty {
+        println!("  Last Qty: {}", last_qty);
+    }
+    if let Some(last_px) = report.last_px {
+        println!("  Last Price: ${:.2}", last_px);
+    }
+    println!("  Cum Qty: {}", report.cum_qty);
+    println!("  Avg Price: ${:.3}", report.avg_px);
+    println!("  Leaves Qty: {}", report.leaves_qty);
+    if let Some(text) = &report.text {
+        println!("  Text: {}", text);
+    }
+}

--- a/alpaca-fix/examples/fix_market_data_request.rs
+++ b/alpaca-fix/examples/fix_market_data_request.rs
@@ -1,0 +1,117 @@
+//! # FIX Market Data Request
+//!
+//! This example demonstrates FIX Market Data Request messages.
+//!
+//! ## Prerequisites
+//!
+//! Set environment variables:
+//! - `ALPACA_API_KEY`: Your Alpaca API key
+//! - `ALPACA_API_SECRET`: Your Alpaca secret key
+//!
+//! ## Usage
+//!
+//! ```bash
+//! cargo run -p alpaca-fix --example fix_market_data_request
+//! ```
+//!
+//! **Note**: This example demonstrates message structures.
+//! FIX protocol requires special access from Alpaca.
+
+use alpaca_fix::{MarketDataEntry, MarketDataRequest, MarketDataSnapshot};
+
+fn main() {
+    println!("=== FIX Market Data Request ===\n");
+
+    // Create a snapshot request
+    println!("--- Snapshot Request ---");
+    let symbols = vec!["AAPL".to_string(), "MSFT".to_string(), "GOOGL".to_string()];
+    let snapshot_request = MarketDataRequest::snapshot(symbols.clone());
+
+    println!("  Request ID: {}", snapshot_request.md_req_id);
+    println!(
+        "  Subscription Type: {} (Snapshot)",
+        snapshot_request.subscription_request_type
+    );
+    println!("  Market Depth: {}", snapshot_request.market_depth);
+    println!("  Symbols: {:?}", snapshot_request.symbols);
+
+    // Create a subscription request
+    println!("\n--- Subscription Request ---");
+    let subscribe_request = MarketDataRequest::subscribe(symbols.clone());
+
+    println!("  Request ID: {}", subscribe_request.md_req_id);
+    println!(
+        "  Subscription Type: {} (Subscribe)",
+        subscribe_request.subscription_request_type
+    );
+    println!("  Market Depth: {}", subscribe_request.market_depth);
+    println!("  Symbols: {:?}", subscribe_request.symbols);
+
+    // Create an unsubscribe request
+    println!("\n--- Unsubscribe Request ---");
+    let unsubscribe_request = MarketDataRequest::unsubscribe(symbols);
+
+    println!("  Request ID: {}", unsubscribe_request.md_req_id);
+    println!(
+        "  Subscription Type: {} (Unsubscribe)",
+        unsubscribe_request.subscription_request_type
+    );
+
+    // Simulate a market data snapshot response
+    println!("\n--- Market Data Snapshot Response ---");
+    let snapshot = MarketDataSnapshot {
+        md_req_id: snapshot_request.md_req_id.clone(),
+        symbol: "AAPL".to_string(),
+        entries: vec![
+            MarketDataEntry {
+                md_entry_type: '0', // Bid
+                md_entry_px: 175.50,
+                md_entry_size: 100.0,
+            },
+            MarketDataEntry {
+                md_entry_type: '1', // Offer
+                md_entry_px: 175.55,
+                md_entry_size: 200.0,
+            },
+            MarketDataEntry {
+                md_entry_type: '2', // Trade
+                md_entry_px: 175.52,
+                md_entry_size: 50.0,
+            },
+        ],
+    };
+
+    println!("  Request ID: {}", snapshot.md_req_id);
+    println!("  Symbol: {}", snapshot.symbol);
+    println!("  Entries:");
+    for entry in &snapshot.entries {
+        let entry_type_name = match entry.md_entry_type {
+            '0' => "Bid",
+            '1' => "Offer",
+            '2' => "Trade",
+            _ => "Unknown",
+        };
+        println!(
+            "    {} - Price: ${:.2}, Size: {}",
+            entry_type_name, entry.md_entry_px, entry.md_entry_size
+        );
+    }
+
+    // Subscription type reference
+    println!("\n--- Subscription Request Type (Tag 263) ---");
+    println!("  0 = Snapshot");
+    println!("  1 = Snapshot + Updates (Subscribe)");
+    println!("  2 = Disable previous Snapshot + Updates (Unsubscribe)");
+
+    // Market data entry type reference
+    println!("\n--- MD Entry Type (Tag 269) ---");
+    println!("  0 = Bid");
+    println!("  1 = Offer");
+    println!("  2 = Trade");
+    println!("  4 = Opening Price");
+    println!("  5 = Closing Price");
+    println!("  7 = Trading Session High Price");
+    println!("  8 = Trading Session Low Price");
+
+    println!("\n=== Example Complete ===");
+}

--- a/alpaca-fix/examples/fix_new_order_single.rs
+++ b/alpaca-fix/examples/fix_new_order_single.rs
@@ -1,0 +1,80 @@
+//! # FIX New Order Single
+//!
+//! This example demonstrates how to create FIX New Order Single messages.
+//!
+//! ## Prerequisites
+//!
+//! Set environment variables:
+//! - `ALPACA_API_KEY`: Your Alpaca API key
+//! - `ALPACA_API_SECRET`: Your Alpaca secret key
+//!
+//! ## Usage
+//!
+//! ```bash
+//! cargo run -p alpaca-fix --example fix_new_order_single
+//! ```
+//!
+//! **Note**: This example creates message structures but does not send them.
+//! FIX protocol requires special access from Alpaca.
+
+use alpaca_fix::{NewOrderSingle, OrdType, Side, TimeInForce};
+
+fn main() {
+    println!("=== FIX New Order Single ===\n");
+
+    // Create a market order
+    println!("--- Market Order ---");
+    let market_order = NewOrderSingle::market("AAPL", Side::Buy, 100.0);
+
+    println!("  Client Order ID: {}", market_order.cl_ord_id);
+    println!("  Symbol: {}", market_order.symbol);
+    println!("  Side: {:?}", market_order.side);
+    println!("  Order Type: {:?}", market_order.ord_type);
+    println!("  Quantity: {}", market_order.order_qty);
+    println!("  Time in Force: {:?}", market_order.time_in_force);
+
+    // Create a limit order
+    println!("\n--- Limit Order ---");
+    let limit_order = NewOrderSingle::limit("MSFT", Side::Sell, 50.0, 350.00)
+        .with_time_in_force(TimeInForce::Gtc);
+
+    println!("  Client Order ID: {}", limit_order.cl_ord_id);
+    println!("  Symbol: {}", limit_order.symbol);
+    println!("  Side: {:?}", limit_order.side);
+    println!("  Order Type: {:?}", limit_order.ord_type);
+    println!("  Quantity: {}", limit_order.order_qty);
+    println!("  Price: ${:.2}", limit_order.price.unwrap_or(0.0));
+    println!("  Time in Force: {:?}", limit_order.time_in_force);
+
+    // Create a stop order
+    println!("\n--- Stop Order ---");
+    let stop_order = NewOrderSingle::stop("TSLA", Side::Sell, 25.0, 200.00);
+
+    println!("  Client Order ID: {}", stop_order.cl_ord_id);
+    println!("  Symbol: {}", stop_order.symbol);
+    println!("  Side: {:?}", stop_order.side);
+    println!("  Order Type: {:?}", stop_order.ord_type);
+    println!("  Quantity: {}", stop_order.order_qty);
+    println!("  Stop Price: ${:.2}", stop_order.stop_px.unwrap_or(0.0));
+
+    // Create order with custom client order ID
+    println!("\n--- Order with Custom ID ---");
+    let custom_order = NewOrderSingle::market("GOOGL", Side::Buy, 10.0)
+        .with_cl_ord_id("MY-ORDER-001")
+        .with_account("my-account-id");
+
+    println!("  Client Order ID: {}", custom_order.cl_ord_id);
+    println!("  Symbol: {}", custom_order.symbol);
+    println!("  Account: {:?}", custom_order.account);
+
+    // FIX tag values
+    println!("\n--- FIX Tag Values ---");
+    println!("  Side Buy (Tag 54): {}", Side::Buy.as_char());
+    println!("  Side Sell (Tag 54): {}", Side::Sell.as_char());
+    println!("  OrdType Market (Tag 40): {}", OrdType::Market.as_char());
+    println!("  OrdType Limit (Tag 40): {}", OrdType::Limit.as_char());
+    println!("  TimeInForce Day (Tag 59): {}", TimeInForce::Day.as_char());
+    println!("  TimeInForce GTC (Tag 59): {}", TimeInForce::Gtc.as_char());
+
+    println!("\n=== Example Complete ===");
+}

--- a/alpaca-fix/examples/fix_order_cancel.rs
+++ b/alpaca-fix/examples/fix_order_cancel.rs
@@ -1,0 +1,86 @@
+//! # FIX Order Cancel
+//!
+//! This example demonstrates how to create FIX Order Cancel and Cancel/Replace messages.
+//!
+//! ## Prerequisites
+//!
+//! Set environment variables:
+//! - `ALPACA_API_KEY`: Your Alpaca API key
+//! - `ALPACA_API_SECRET`: Your Alpaca secret key
+//!
+//! ## Usage
+//!
+//! ```bash
+//! cargo run -p alpaca-fix --example fix_order_cancel
+//! ```
+//!
+//! **Note**: This example creates message structures but does not send them.
+//! FIX protocol requires special access from Alpaca.
+
+use alpaca_fix::{OrdType, OrderCancelReplaceRequest, OrderCancelRequest, Side};
+
+fn main() {
+    println!("=== FIX Order Cancel ===\n");
+
+    // Create an order cancel request
+    println!("--- Order Cancel Request (MsgType F) ---");
+    let cancel_request = OrderCancelRequest::new("original-order-id-123", "AAPL", Side::Buy);
+
+    println!(
+        "  Original Client Order ID: {}",
+        cancel_request.orig_cl_ord_id
+    );
+    println!("  New Client Order ID: {}", cancel_request.cl_ord_id);
+    println!("  Symbol: {}", cancel_request.symbol);
+    println!("  Side: {:?}", cancel_request.side);
+
+    // Create an order cancel/replace request (modify order)
+    println!("\n--- Order Cancel/Replace Request (MsgType G) ---");
+    let replace_request = OrderCancelReplaceRequest::new(
+        "original-order-id-456",
+        "MSFT",
+        Side::Sell,
+        OrdType::Limit,
+        75.0,
+    )
+    .with_price(355.00);
+
+    println!(
+        "  Original Client Order ID: {}",
+        replace_request.orig_cl_ord_id
+    );
+    println!("  New Client Order ID: {}", replace_request.cl_ord_id);
+    println!("  Symbol: {}", replace_request.symbol);
+    println!("  Side: {:?}", replace_request.side);
+    println!("  Order Type: {:?}", replace_request.ord_type);
+    println!("  New Quantity: {}", replace_request.order_qty);
+    println!("  New Price: ${:.2}", replace_request.price.unwrap_or(0.0));
+
+    // Demonstrate cancel workflow
+    println!("\n--- Cancel Workflow ---");
+    println!("  1. Send NewOrderSingle (MsgType D)");
+    println!("     -> Receive ExecutionReport with OrdStatus=New");
+    println!("  2. Send OrderCancelRequest (MsgType F)");
+    println!("     -> Receive ExecutionReport with OrdStatus=Canceled");
+    println!("     OR");
+    println!("     -> Receive OrderCancelReject if cancel fails");
+
+    // Demonstrate replace workflow
+    println!("\n--- Replace Workflow ---");
+    println!("  1. Send NewOrderSingle (MsgType D)");
+    println!("     -> Receive ExecutionReport with OrdStatus=New");
+    println!("  2. Send OrderCancelReplaceRequest (MsgType G)");
+    println!("     -> Receive ExecutionReport with OrdStatus=Replaced");
+    println!("     OR");
+    println!("     -> Receive OrderCancelReject if replace fails");
+
+    // FIX message type codes
+    println!("\n--- FIX Message Types ---");
+    println!("  D = New Order Single");
+    println!("  F = Order Cancel Request");
+    println!("  G = Order Cancel/Replace Request");
+    println!("  8 = Execution Report");
+    println!("  9 = Order Cancel Reject");
+
+    println!("\n=== Example Complete ===");
+}

--- a/alpaca-fix/examples/fix_session_setup.rs
+++ b/alpaca-fix/examples/fix_session_setup.rs
@@ -1,0 +1,84 @@
+//! # FIX Session Setup
+//!
+//! This example demonstrates how to configure and set up a FIX session.
+//!
+//! ## Prerequisites
+//!
+//! Set environment variables:
+//! - `ALPACA_API_KEY`: Your Alpaca API key
+//! - `ALPACA_API_SECRET`: Your Alpaca secret key
+//!
+//! ## Usage
+//!
+//! ```bash
+//! cargo run -p alpaca-fix --example fix_session_setup
+//! ```
+//!
+//! **Note**: FIX protocol requires special access from Alpaca. Contact Alpaca
+//! support to enable FIX access for your account.
+
+use alpaca_base::Credentials;
+use alpaca_fix::{FixClient, FixConfig, FixVersion};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("=== FIX Session Setup ===\n");
+
+    // Load credentials from environment
+    let credentials = Credentials::from_env()?;
+    println!("Credentials loaded from environment");
+
+    // Create FIX configuration using builder pattern
+    println!("\n--- FIX Configuration ---");
+
+    let config = FixConfig::builder()
+        .version(FixVersion::Fix44)
+        .sender_comp_id("YOUR_SENDER_ID")
+        .target_comp_id("ALPACA")
+        .host("fix.alpaca.markets")
+        .port(5001)
+        .heartbeat_interval_secs(30)
+        .reconnect_enabled(true)
+        .reconnect_max_attempts(5)
+        .reconnect_delay_ms(1000)
+        .message_logging(true)
+        .reset_on_logon(false)
+        .build();
+
+    println!("  Version: {}", config.version);
+    println!("  Sender CompID: {}", config.sender_comp_id);
+    println!("  Target CompID: {}", config.target_comp_id);
+    println!("  Host: {}", config.host);
+    println!("  Port: {}", config.port);
+    println!("  Heartbeat Interval: {}s", config.heartbeat_interval_secs);
+    println!("  Reconnect Enabled: {}", config.reconnect_enabled);
+    println!(
+        "  Max Reconnect Attempts: {}",
+        config.reconnect_max_attempts
+    );
+    println!("  Reconnect Delay: {}ms", config.reconnect_delay_ms);
+    println!("  Message Logging: {}", config.message_logging);
+    println!("  Reset on Logon: {}", config.reset_on_logon);
+
+    // Create FIX client
+    println!("\n--- Creating FIX Client ---");
+    let client = FixClient::new(credentials, config);
+    println!("  FIX client created: {:?}", client);
+
+    // Demonstrate FIX versions
+    println!("\n--- Supported FIX Versions ---");
+    println!("  FIX 4.2: {}", FixVersion::Fix42.begin_string());
+    println!("  FIX 4.4: {}", FixVersion::Fix44.begin_string());
+
+    // Note about connection
+    println!("\n--- Connection Notes ---");
+    println!("  To connect to the FIX server, use:");
+    println!("    client.connect().await?;");
+    println!();
+    println!("  FIX protocol requires:");
+    println!("    1. Special access enabled by Alpaca");
+    println!("    2. Valid Sender CompID assigned by Alpaca");
+    println!("    3. Network access to fix.alpaca.markets:5001");
+
+    println!("\n=== Example Complete ===");
+    Ok(())
+}


### PR DESCRIPTION
Add 5 examples for alpaca-fix crate:

- fix_session_setup.rs: Configure and set up a FIX session
- fix_new_order_single.rs: Create New Order Single messages
- fix_order_cancel.rs: Create Cancel and Cancel/Replace messages
- fix_execution_report.rs: Execution Report message structure
- fix_market_data_request.rs: Market Data Request messages

Also:
- Create examples/ directory for alpaca-fix
- Update alpaca-fix README with examples table

Closes #53