### PR TITLE
feat(examples): implement HTTP Broker API examples (E008)

### DIFF
--- a/alpaca-http/README.md
+++ b/alpaca-http/README.md
@@ -49,6 +49,45 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
+## Examples
+
+Run examples with `cargo run -p alpaca-http --example <name>`:
+
+### Trading Examples
+
+| Example | Description |
+|---------|-------------|
+| `http_get_account` | Get account information |
+| `http_create_market_order` | Create market orders |
+| `http_create_limit_order` | Create limit orders |
+| `http_list_orders` | List and filter orders |
+| `http_cancel_order` | Cancel orders |
+| `http_get_positions` | List positions |
+| `http_close_position` | Close positions |
+
+### Market Data Examples
+
+| Example | Description |
+|---------|-------------|
+| `http_get_bars` | Fetch historical bars |
+| `http_get_quotes` | Fetch quote data |
+| `http_get_trades` | Fetch trade data |
+| `http_list_assets` | List and filter assets |
+| `http_get_clock` | Get market clock |
+| `http_get_calendar` | Get market calendar |
+
+### Broker API Examples
+
+| Example | Description |
+|---------|-------------|
+| `http_create_broker_account` | Create broker accounts |
+| `http_get_broker_account` | Get and list broker accounts |
+| `http_ach_relationships` | Manage ACH funding |
+| `http_transfers` | Create and manage transfers |
+| `http_journals` | Create journal entries |
+| `http_documents` | List and retrieve documents |
+| `http_ira_contributions` | Manage IRA contributions |
+
 ## Contribution and Contact
 
 We welcome contributions to this project! If you would like to contribute, please follow these steps:

--- a/alpaca-http/examples/http_ach_relationships.rs
+++ b/alpaca-http/examples/http_ach_relationships.rs
@@ -1,0 +1,109 @@
+//! # ACH Relationships
+//!
+//! This example demonstrates how to manage ACH funding relationships
+//! for broker accounts using the Alpaca Broker API.
+//!
+//! ## Prerequisites
+//!
+//! Set environment variables:
+//! - `ALPACA_API_KEY`: Your Alpaca Broker API key
+//! - `ALPACA_API_SECRET`: Your Alpaca Broker secret key
+//!
+//! ## Usage
+//!
+//! ```bash
+//! cargo run -p alpaca-http --example http_ach_relationships
+//! ```
+//!
+//! **Note**: This example demonstrates the API structure. Broker API
+//! requires special credentials.
+
+fn main() {
+    println!("=== ACH Relationships ===\n");
+
+    // What is ACH?
+    println!("--- What is ACH? ---");
+    println!("  ACH (Automated Clearing House) is a network for");
+    println!("  electronic fund transfers between bank accounts.");
+    println!("  Used for deposits and withdrawals from trading accounts.");
+
+    // Create ACH relationship
+    println!("\n--- Create ACH Relationship ---");
+    println!("  Required fields:");
+    println!("    - account_owner_name: Name on the bank account");
+    println!("    - bank_account_type: CHECKING or SAVINGS");
+    println!("    - bank_account_number: Bank account number");
+    println!("    - bank_routing_number: 9-digit ABA routing number");
+    println!();
+    println!("  API call:");
+    println!("    let request = CreateAchRelationshipRequest {{");
+    println!("        account_owner_name: \"John Doe\".to_string(),");
+    println!("        bank_account_type: BankAccountType::Checking,");
+    println!("        bank_account_number: \"123456789\".to_string(),");
+    println!("        bank_routing_number: \"021000021\".to_string(),");
+    println!("        nickname: Some(\"My Checking\".to_string()),");
+    println!("    }};");
+    println!("    let ach = client.create_ach_relationship(&account_id, &request).await?;");
+
+    // ACH relationship states
+    println!("\n--- ACH Relationship States ---");
+    println!("  QUEUED: Relationship creation queued");
+    println!("  PENDING: Awaiting micro-deposit verification");
+    println!("  APPROVED: Ready for transfers");
+    println!("  CANCELED: Relationship canceled");
+
+    // List ACH relationships
+    println!("\n--- List ACH Relationships ---");
+    println!("  let relationships = client.list_ach_relationships(&account_id).await?;");
+    println!("  for ach in relationships {{");
+    println!("      println!(\"ID: {{}}\", ach.id);");
+    println!("      println!(\"Bank: {{}}\", ach.bank_name);");
+    println!("      println!(\"Status: {{:?}}\", ach.status);");
+    println!("      println!(\"Last 4: {{}}\", ach.account_last_four);");
+    println!("  }}");
+
+    // Micro-deposit verification
+    println!("\n--- Micro-Deposit Verification ---");
+    println!("  When ACH is PENDING, verify with micro-deposits:");
+    println!("  1. Alpaca sends two small deposits (e.g., $0.12, $0.34)");
+    println!("  2. User checks bank statement for amounts");
+    println!("  3. Submit amounts for verification:");
+    println!();
+    println!("    let amounts = [\"0.12\", \"0.34\"];");
+    println!("    client.verify_ach_relationship(&account_id, &ach_id, &amounts).await?;");
+
+    // Delete ACH relationship
+    println!("\n--- Delete ACH Relationship ---");
+    println!("  client.delete_ach_relationship(&account_id, &ach_id).await?;");
+    println!("  Note: Cannot delete if pending transfers exist");
+
+    // Bank account types
+    println!("\n--- Bank Account Types ---");
+    println!("  CHECKING: Standard checking account");
+    println!("  SAVINGS: Savings account");
+
+    // Security considerations
+    println!("\n--- Security Considerations ---");
+    println!("1. Never log full bank account numbers");
+    println!("2. Use HTTPS for all API calls");
+    println!("3. Validate routing numbers before submission");
+    println!("4. Implement rate limiting on verification attempts");
+    println!("5. Monitor for suspicious activity patterns");
+
+    // Common errors
+    println!("\n--- Common Errors ---");
+    println!("  invalid_routing_number: ABA routing number not valid");
+    println!("  duplicate_relationship: Bank account already linked");
+    println!("  verification_failed: Micro-deposit amounts incorrect");
+    println!("  account_not_found: Broker account doesn't exist");
+
+    // Best practices
+    println!("\n--- Best Practices ---");
+    println!("1. Allow users to nickname their bank accounts");
+    println!("2. Show only last 4 digits of account numbers");
+    println!("3. Provide clear verification instructions");
+    println!("4. Set reasonable timeout for verification (3-5 days)");
+    println!("5. Send reminders for pending verifications");
+
+    println!("\n=== Example Complete ===");
+}

--- a/alpaca-http/examples/http_create_broker_account.rs
+++ b/alpaca-http/examples/http_create_broker_account.rs
@@ -1,0 +1,136 @@
+//! # Create Broker Account
+//!
+//! This example demonstrates how to create a new broker account
+//! using the Alpaca Broker API.
+//!
+//! ## Prerequisites
+//!
+//! Set environment variables:
+//! - `ALPACA_API_KEY`: Your Alpaca Broker API key
+//! - `ALPACA_API_SECRET`: Your Alpaca Broker secret key
+//!
+//! ## Usage
+//!
+//! ```bash
+//! cargo run -p alpaca-http --example http_create_broker_account
+//! ```
+//!
+//! **Note**: This example demonstrates the API structure but does not
+//! actually create accounts to avoid unintended side effects.
+
+use alpaca_base::{
+    Agreement, AgreementType, Contact, CreateBrokerAccountRequest, Disclosures, Identity,
+    TaxIdType, TrustedContact,
+};
+
+fn main() {
+    println!("=== Create Broker Account ===\n");
+
+    // Step 1: Create contact information
+    println!("--- Step 1: Contact Information ---");
+    let contact = Contact::new("john.doe@example.com", "New York", "10001", "USA")
+        .phone("+1-555-123-4567")
+        .street("123 Main Street")
+        .street("Apt 4B")
+        .state("NY");
+
+    println!("  Email: {}", contact.email_address);
+    println!("  Phone: {:?}", contact.phone_number);
+    println!("  City: {}", contact.city);
+    println!("  State: {:?}", contact.state);
+    println!("  Postal Code: {}", contact.postal_code);
+    println!("  Country: {}", contact.country);
+
+    // Step 2: Create identity information
+    println!("\n--- Step 2: Identity Information ---");
+    let identity = Identity::new("John", "Doe", "1990-01-15")
+        .tax_id("123-45-6789", TaxIdType::UsaSsn)
+        .citizenship("USA");
+
+    println!("  Name: {} {}", identity.given_name, identity.family_name);
+    println!("  Date of Birth: {}", identity.date_of_birth);
+    println!("  Tax ID Type: {:?}", identity.tax_id_type);
+    println!("  Citizenship: {:?}", identity.country_of_citizenship);
+
+    // Step 3: Create disclosures
+    println!("\n--- Step 3: Disclosures ---");
+    let disclosures = Disclosures::new().control_person(false).employment(
+        "employed",
+        "Tech Corp",
+        "Software Engineer",
+    );
+
+    println!("  Is Control Person: {}", disclosures.is_control_person);
+    println!(
+        "  Is Affiliated with Exchange/FINRA: {}",
+        disclosures.is_affiliated_exchange_or_finra
+    );
+    println!(
+        "  Is Politically Exposed: {}",
+        disclosures.is_politically_exposed
+    );
+    println!("  Employment Status: {:?}", disclosures.employment_status);
+    println!("  Employer: {:?}", disclosures.employer_name);
+
+    // Step 4: Create agreements
+    println!("\n--- Step 4: Agreements ---");
+    let now = "2024-01-15T10:30:00Z";
+    let ip = "192.168.1.100";
+
+    let agreements = vec![
+        Agreement::new(AgreementType::CustomerAgreement, now, ip),
+        Agreement::new(AgreementType::MarginAgreement, now, ip),
+        Agreement::new(AgreementType::AccountAgreement, now, ip),
+    ];
+
+    for agreement in &agreements {
+        println!(
+            "  {:?} - signed at {}",
+            agreement.agreement, agreement.signed_at
+        );
+    }
+
+    // Step 5: Create trusted contact (optional)
+    println!("\n--- Step 5: Trusted Contact (Optional) ---");
+    let trusted_contact = TrustedContact::new("Jane", "Doe")
+        .email("jane.doe@example.com")
+        .phone("+1-555-987-6543");
+
+    println!(
+        "  Name: {} {}",
+        trusted_contact.given_name, trusted_contact.family_name
+    );
+    println!("  Email: {:?}", trusted_contact.email_address);
+    println!("  Phone: {:?}", trusted_contact.phone_number);
+
+    // Step 6: Build the complete request
+    println!("\n--- Step 6: Build Request ---");
+    let request = CreateBrokerAccountRequest::new(contact, identity, disclosures, agreements)
+        .trusted_contact(trusted_contact)
+        .enabled_assets(vec!["us_equity".to_string(), "crypto".to_string()]);
+
+    println!("  Request built successfully");
+    println!("  Enabled assets: {:?}", request.enabled_assets);
+
+    // API call demonstration
+    println!("\n--- API Call ---");
+    println!("  To create the account:");
+    println!("    let account = client.create_broker_account(&request).await?;");
+    println!("    println!(\"Account ID: {{}}\", account.id);");
+    println!("    println!(\"Status: {{:?}}\", account.status);");
+
+    // Account lifecycle
+    println!("\n--- Account Lifecycle ---");
+    println!("  1. ONBOARDING: Initial state after creation");
+    println!("  2. SUBMISSION_FAILED: KYC/AML check failed");
+    println!("  3. SUBMITTED: Documents submitted for review");
+    println!("  4. ACTION_REQUIRED: Additional info needed");
+    println!("  5. APPROVAL_PENDING: Under review");
+    println!("  6. APPROVED: Ready for trading (limited)");
+    println!("  7. ACTIVE: Fully active account");
+    println!("  8. REJECTED: Application rejected");
+    println!("  9. DISABLED: Account disabled");
+    println!(" 10. ACCOUNT_CLOSED: Account closed");
+
+    println!("\n=== Example Complete ===");
+}

--- a/alpaca-http/examples/http_documents.rs
+++ b/alpaca-http/examples/http_documents.rs
@@ -1,0 +1,114 @@
+//! # Documents
+//!
+//! This example demonstrates how to list and retrieve documents
+//! for broker accounts using the Alpaca Broker API.
+//!
+//! ## Prerequisites
+//!
+//! Set environment variables:
+//! - `ALPACA_API_KEY`: Your Alpaca Broker API key
+//! - `ALPACA_API_SECRET`: Your Alpaca Broker secret key
+//!
+//! ## Usage
+//!
+//! ```bash
+//! cargo run -p alpaca-http --example http_documents
+//! ```
+//!
+//! **Note**: This example demonstrates the API structure. Broker API
+//! requires special credentials.
+
+fn main() {
+    println!("=== Documents ===\n");
+
+    // Document types
+    println!("--- Document Types ---");
+    println!("  account_statement: Monthly account statements");
+    println!("  trade_confirmation: Trade confirmations");
+    println!("  tax_statement: Tax documents (1099, etc.)");
+    println!("  account_application: Account application documents");
+    println!("  margin_disclosure: Margin agreement disclosures");
+
+    // List documents
+    println!("\n--- List Documents ---");
+    println!("  let params = ListDocumentsParams::new()");
+    println!("      .start(\"2024-01-01\")");
+    println!("      .end(\"2024-12-31\")");
+    println!("      .doc_type(DocumentType::AccountStatement);");
+    println!("  let documents = client.list_documents(&account_id, &params).await?;");
+    println!("  for doc in documents {{");
+    println!("      println!(\"ID: {{}}\", doc.id);");
+    println!("      println!(\"Type: {{:?}}\", doc.document_type);");
+    println!("      println!(\"Date: {{}}\", doc.date);");
+    println!("  }}");
+
+    // Get document
+    println!("\n--- Get Document ---");
+    println!("  let document = client.get_document(&account_id, &document_id).await?;");
+    println!("  println!(\"ID: {{}}\", document.id);");
+    println!("  println!(\"Type: {{:?}}\", document.document_type);");
+    println!("  println!(\"Name: {{}}\", document.name);");
+
+    // Download document
+    println!("\n--- Download Document ---");
+    println!("  let content = client.download_document(&account_id, &document_id).await?;");
+    println!("  // content is the raw PDF/document bytes");
+    println!("  std::fs::write(\"statement.pdf\", content)?;");
+
+    // Document fields
+    println!("\n--- Document Fields ---");
+    println!("  id: Unique document identifier");
+    println!("  document_type: Type of document");
+    println!("  document_sub_type: Sub-type (if applicable)");
+    println!("  name: Document name/filename");
+    println!("  date: Document date");
+    println!("  created_at: When document was created");
+
+    // Tax documents
+    println!("\n--- Tax Documents ---");
+    println!("  1099-B: Proceeds from broker transactions");
+    println!("  1099-DIV: Dividend income");
+    println!("  1099-INT: Interest income");
+    println!("  1099-MISC: Miscellaneous income");
+    println!();
+    println!("  Tax documents are typically available in February");
+    println!("  for the previous tax year.");
+
+    // Account statements
+    println!("\n--- Account Statements ---");
+    println!("  Generated monthly");
+    println!("  Contains:");
+    println!("    - Account summary");
+    println!("    - Position details");
+    println!("    - Transaction history");
+    println!("    - Fees and charges");
+
+    // Trade confirmations
+    println!("\n--- Trade Confirmations ---");
+    println!("  Generated for each trade");
+    println!("  Contains:");
+    println!("    - Trade details (symbol, qty, price)");
+    println!("    - Execution time");
+    println!("    - Commission and fees");
+    println!("    - Settlement date");
+
+    // Regulatory requirements
+    println!("\n--- Regulatory Requirements ---");
+    println!("  Brokers must provide:");
+    println!("  - Monthly statements");
+    println!("  - Trade confirmations");
+    println!("  - Annual tax documents");
+    println!("  - Regulatory disclosures");
+    println!();
+    println!("  Documents must be retained for regulatory periods.");
+
+    // Best practices
+    println!("\n--- Best Practices ---");
+    println!("1. Provide easy document access to customers");
+    println!("2. Send notifications when new documents are available");
+    println!("3. Allow document download in multiple formats");
+    println!("4. Implement document search and filtering");
+    println!("5. Maintain document retention policies");
+
+    println!("\n=== Example Complete ===");
+}

--- a/alpaca-http/examples/http_get_broker_account.rs
+++ b/alpaca-http/examples/http_get_broker_account.rs
@@ -1,0 +1,108 @@
+//! # Get Broker Account
+//!
+//! This example demonstrates how to retrieve and list broker accounts
+//! using the Alpaca Broker API.
+//!
+//! ## Prerequisites
+//!
+//! Set environment variables:
+//! - `ALPACA_API_KEY`: Your Alpaca Broker API key
+//! - `ALPACA_API_SECRET`: Your Alpaca Broker secret key
+//!
+//! ## Usage
+//!
+//! ```bash
+//! cargo run -p alpaca-http --example http_get_broker_account
+//! ```
+//!
+//! **Note**: This example demonstrates the API structure. Broker API
+//! requires special credentials.
+
+use alpaca_base::{BrokerAccountStatus, ListBrokerAccountsParams};
+
+fn main() {
+    println!("=== Get Broker Account ===\n");
+
+    // Get single account by ID
+    println!("--- Get Account by ID ---");
+    println!("  let account = client.get_broker_account(\"account-uuid\").await?;");
+    println!("  println!(\"Account ID: {{}}\", account.id);");
+    println!("  println!(\"Account Number: {{}}\", account.account_number);");
+    println!("  println!(\"Status: {{:?}}\", account.status);");
+
+    // Account fields
+    println!("\n--- Account Fields ---");
+    println!("  id: Unique account identifier (UUID)");
+    println!("  account_number: Human-readable account number");
+    println!("  status: Current account status");
+    println!("  crypto_status: Crypto trading status (if enabled)");
+    println!("  currency: Account currency (e.g., USD)");
+    println!("  created_at: Account creation timestamp");
+
+    // List accounts with parameters
+    println!("\n--- List Accounts ---");
+    let params = ListBrokerAccountsParams::new()
+        .status(BrokerAccountStatus::Active)
+        .query("john");
+
+    println!("  Filter parameters:");
+    println!("    Status: {:?}", params.status);
+    println!("    Query: {:?}", params.query);
+    println!("    Sort: {:?}", params.sort);
+
+    println!("\n  API call:");
+    println!("    let accounts = client.list_broker_accounts(&params).await?;");
+    println!("    for account in accounts {{");
+    println!("        println!(\"{{}} - {{:?}}\", account.id, account.status);");
+    println!("    }}");
+
+    // Filter by status
+    println!("\n--- Filter by Status ---");
+    let statuses = [
+        (BrokerAccountStatus::Onboarding, "New accounts being set up"),
+        (BrokerAccountStatus::Active, "Fully active accounts"),
+        (BrokerAccountStatus::Approved, "Awaiting full activation"),
+        (BrokerAccountStatus::ActionRequired, "Need user action"),
+        (BrokerAccountStatus::Disabled, "Disabled accounts"),
+    ];
+
+    for (status, description) in statuses {
+        println!("  {:?}: {}", status, description);
+    }
+
+    // Filter by date range
+    println!("\n--- Filter by Date ---");
+    println!("  let params = ListBrokerAccountsParams::new()");
+    println!("      .created_after(\"2024-01-01\")");
+    println!("      .created_before(\"2024-12-31\");");
+
+    // Pagination
+    println!("\n--- Pagination ---");
+    println!("  Results are paginated by default");
+    println!("  Use query parameters to control:");
+    println!("    - page_token: Token for next page");
+    println!("    - page_size: Number of results per page");
+
+    // Update account
+    println!("\n--- Update Account ---");
+    println!("  let update = UpdateBrokerAccountRequest {{");
+    println!("      contact: Some(new_contact),");
+    println!("      ..Default::default()");
+    println!("  }};");
+    println!("  let updated = client.update_broker_account(&id, &update).await?;");
+
+    // Delete account
+    println!("\n--- Close Account ---");
+    println!("  client.close_broker_account(&account_id).await?;");
+    println!("  Note: This initiates account closure process");
+
+    // Best practices
+    println!("\n--- Best Practices ---");
+    println!("1. Cache account IDs to avoid repeated lookups");
+    println!("2. Use status filters to find accounts needing attention");
+    println!("3. Implement pagination for large account lists");
+    println!("4. Monitor account status changes via webhooks");
+    println!("5. Store account_number for customer reference");
+
+    println!("\n=== Example Complete ===");
+}

--- a/alpaca-http/examples/http_ira_contributions.rs
+++ b/alpaca-http/examples/http_ira_contributions.rs
@@ -1,0 +1,125 @@
+//! # IRA Contributions
+//!
+//! This example demonstrates how to manage IRA contributions
+//! for broker accounts using the Alpaca Broker API.
+//!
+//! ## Prerequisites
+//!
+//! Set environment variables:
+//! - `ALPACA_API_KEY`: Your Alpaca Broker API key
+//! - `ALPACA_API_SECRET`: Your Alpaca Broker secret key
+//!
+//! ## Usage
+//!
+//! ```bash
+//! cargo run -p alpaca-http --example http_ira_contributions
+//! ```
+//!
+//! **Note**: This example demonstrates the API structure. Broker API
+//! requires special credentials and IRA-enabled accounts.
+
+fn main() {
+    println!("=== IRA Contributions ===\n");
+
+    // IRA account types
+    println!("--- IRA Account Types ---");
+    println!("  Traditional IRA: Tax-deductible contributions, taxed on withdrawal");
+    println!("  Roth IRA: After-tax contributions, tax-free growth and withdrawal");
+    println!("  SEP IRA: For self-employed and small business owners");
+    println!("  SIMPLE IRA: For small businesses with employees");
+
+    // Contribution limits (2024)
+    println!("\n--- Contribution Limits (2024) ---");
+    println!("  Under 50: $7,000 per year");
+    println!("  50 and over: $8,000 per year (includes $1,000 catch-up)");
+    println!();
+    println!("  Note: Limits apply across all IRA accounts combined");
+
+    // List contributions
+    println!("\n--- List IRA Contributions ---");
+    println!("  let params = ListIraContributionsParams::new()");
+    println!("      .tax_year(2024)");
+    println!("      .contribution_type(IraContributionType::Regular);");
+    println!("  let contributions = client.list_ira_contributions(&account_id, &params).await?;");
+    println!("  for contrib in contributions {{");
+    println!("      println!(\"Amount: ${{}}\", contrib.amount);");
+    println!("      println!(\"Type: {{:?}}\", contrib.contribution_type);");
+    println!("      println!(\"Tax Year: {{}}\", contrib.tax_year);");
+    println!("  }}");
+
+    // Contribution types
+    println!("\n--- Contribution Types ---");
+    println!("  REGULAR: Standard annual contribution");
+    println!("  ROLLOVER: Transfer from another retirement account");
+    println!("  CONVERSION: Roth conversion from Traditional IRA");
+    println!("  RECHARACTERIZATION: Change contribution type");
+    println!("  EMPLOYER: Employer contribution (SEP/SIMPLE)");
+
+    // Create contribution
+    println!("\n--- Create IRA Contribution ---");
+    println!("  let request = CreateIraContributionRequest {{");
+    println!("      amount: \"5000.00\".to_string(),");
+    println!("      contribution_type: IraContributionType::Regular,");
+    println!("      tax_year: 2024,");
+    println!("  }};");
+    println!("  let contribution = client.create_ira_contribution(&account_id, &request).await?;");
+
+    // Contribution deadlines
+    println!("\n--- Contribution Deadlines ---");
+    println!("  Regular contributions: April 15 of following year");
+    println!("  Example: 2024 contributions due by April 15, 2025");
+    println!();
+    println!("  Employer contributions (SEP): Tax filing deadline + extensions");
+
+    // Distributions
+    println!("\n--- IRA Distributions ---");
+    println!("  let request = CreateIraDistributionRequest {{");
+    println!("      amount: \"1000.00\".to_string(),");
+    println!("      distribution_type: IraDistributionType::Normal,");
+    println!("      federal_tax_withholding: Some(\"10\".to_string()),");
+    println!("      state_tax_withholding: Some(\"5\".to_string()),");
+    println!("  }};");
+    println!("  let distribution = client.create_ira_distribution(&account_id, &request).await?;");
+
+    // Distribution types
+    println!("\n--- Distribution Types ---");
+    println!("  NORMAL: Standard distribution (59½ or older)");
+    println!("  EARLY: Early distribution (before 59½, may have penalty)");
+    println!("  QUALIFIED: Qualified Roth distribution");
+    println!("  REQUIRED: Required Minimum Distribution (RMD)");
+    println!("  ROLLOVER: Transfer to another retirement account");
+
+    // Tax withholding
+    println!("\n--- Tax Withholding ---");
+    println!("  Federal: Default 10% for Traditional IRA distributions");
+    println!("  State: Varies by state");
+    println!();
+    println!("  Roth IRA qualified distributions: No withholding required");
+
+    // Beneficiaries
+    println!("\n--- IRA Beneficiaries ---");
+    println!("  let beneficiaries = client.list_ira_beneficiaries(&account_id).await?;");
+    println!("  for ben in beneficiaries {{");
+    println!("      println!(\"Name: {{}} {{}}\", ben.first_name, ben.last_name);");
+    println!("      println!(\"Percentage: {{}}%\", ben.percentage);");
+    println!("      println!(\"Type: {{:?}}\", ben.beneficiary_type);");
+    println!("  }}");
+
+    // Compliance
+    println!("\n--- Compliance Considerations ---");
+    println!("1. Verify contribution limits before accepting");
+    println!("2. Track contributions across tax years");
+    println!("3. Calculate RMDs for applicable accounts");
+    println!("4. Report distributions to IRS (Form 1099-R)");
+    println!("5. Maintain beneficiary designations");
+
+    // Best practices
+    println!("\n--- Best Practices ---");
+    println!("1. Provide contribution limit tracking to users");
+    println!("2. Send reminders before contribution deadlines");
+    println!("3. Calculate and display RMD amounts");
+    println!("4. Allow easy beneficiary management");
+    println!("5. Provide tax withholding calculators");
+
+    println!("\n=== Example Complete ===");
+}

--- a/alpaca-http/examples/http_journals.rs
+++ b/alpaca-http/examples/http_journals.rs
@@ -1,0 +1,129 @@
+//! # Journals
+//!
+//! This example demonstrates how to create and manage journal entries
+//! for transferring assets between broker accounts.
+//!
+//! ## Prerequisites
+//!
+//! Set environment variables:
+//! - `ALPACA_API_KEY`: Your Alpaca Broker API key
+//! - `ALPACA_API_SECRET`: Your Alpaca Broker secret key
+//!
+//! ## Usage
+//!
+//! ```bash
+//! cargo run -p alpaca-http --example http_journals
+//! ```
+//!
+//! **Note**: This example demonstrates the API structure. Broker API
+//! requires special credentials.
+
+fn main() {
+    println!("=== Journals ===\n");
+
+    // What are journals?
+    println!("--- What are Journals? ---");
+    println!("  Journals are internal transfers between broker accounts.");
+    println!("  Used for:");
+    println!("    - Moving cash between accounts");
+    println!("    - Transferring securities between accounts");
+    println!("    - Correcting errors");
+    println!("    - Fee collection");
+
+    // Journal types
+    println!("\n--- Journal Entry Types ---");
+    println!("  JNLC: Cash journal (transfer cash)");
+    println!("  JNLS: Security journal (transfer securities)");
+
+    // Create cash journal
+    println!("\n--- Create Cash Journal (JNLC) ---");
+    println!("  let request = CreateJournalRequest {{");
+    println!("      entry_type: JournalEntryType::Jnlc,");
+    println!("      from_account: \"source-account-uuid\".to_string(),");
+    println!("      to_account: \"dest-account-uuid\".to_string(),");
+    println!("      amount: \"100.00\".to_string(),");
+    println!("      symbol: None,");
+    println!("      qty: None,");
+    println!("      description: Some(\"Monthly fee\".to_string()),");
+    println!("  }};");
+    println!("  let journal = client.create_journal(&request).await?;");
+
+    // Create security journal
+    println!("\n--- Create Security Journal (JNLS) ---");
+    println!("  let request = CreateJournalRequest {{");
+    println!("      entry_type: JournalEntryType::Jnls,");
+    println!("      from_account: \"source-account-uuid\".to_string(),");
+    println!("      to_account: \"dest-account-uuid\".to_string(),");
+    println!("      amount: None,");
+    println!("      symbol: Some(\"AAPL\".to_string()),");
+    println!("      qty: Some(\"10\".to_string()),");
+    println!("      description: Some(\"Security transfer\".to_string()),");
+    println!("  }};");
+    println!("  let journal = client.create_journal(&request).await?;");
+
+    // Journal states
+    println!("\n--- Journal States ---");
+    println!("  QUEUED: Journal queued for processing");
+    println!("  PENDING: Journal being processed");
+    println!("  EXECUTED: Journal completed successfully");
+    println!("  CANCELED: Journal canceled");
+    println!("  REJECTED: Journal rejected");
+
+    // List journals
+    println!("\n--- List Journals ---");
+    println!("  let params = ListJournalsParams::new()");
+    println!("      .entry_type(JournalEntryType::Jnlc)");
+    println!("      .after(\"2024-01-01\")");
+    println!("      .before(\"2024-12-31\");");
+    println!("  let journals = client.list_journals(&params).await?;");
+
+    // Get journal
+    println!("\n--- Get Journal ---");
+    println!("  let journal = client.get_journal(&journal_id).await?;");
+    println!("  println!(\"ID: {{}}\", journal.id);");
+    println!("  println!(\"Type: {{:?}}\", journal.entry_type);");
+    println!("  println!(\"Status: {{:?}}\", journal.status);");
+
+    // Cancel journal
+    println!("\n--- Cancel Journal ---");
+    println!("  client.cancel_journal(&journal_id).await?;");
+    println!("  Note: Only QUEUED or PENDING journals can be canceled");
+
+    // Batch journals
+    println!("\n--- Batch Journals ---");
+    println!("  Create multiple journals in one request:");
+    println!("  let entries = vec![");
+    println!("      BatchJournalEntry {{ to_account: \"acc1\", amount: \"10.00\" }},");
+    println!("      BatchJournalEntry {{ to_account: \"acc2\", amount: \"20.00\" }},");
+    println!("  ];");
+    println!("  let request = BatchJournalRequest {{");
+    println!("      entry_type: JournalEntryType::Jnlc,");
+    println!("      from_account: \"source-account\".to_string(),");
+    println!("      entries,");
+    println!("  }};");
+    println!("  let results = client.create_batch_journal(&request).await?;");
+
+    // Use cases
+    println!("\n--- Common Use Cases ---");
+    println!("  1. Fee Collection");
+    println!("     - Transfer fees from customer to firm account");
+    println!();
+    println!("  2. Interest Payments");
+    println!("     - Distribute interest to customer accounts");
+    println!();
+    println!("  3. Error Correction");
+    println!("     - Move funds/securities to correct accounts");
+    println!();
+    println!("  4. Account Consolidation");
+    println!("     - Merge multiple accounts into one");
+
+    // Best practices
+    println!("\n--- Best Practices ---");
+    println!("1. Always include descriptive notes");
+    println!("2. Validate account balances before journaling");
+    println!("3. Use batch journals for efficiency");
+    println!("4. Keep audit trail of all journals");
+    println!("5. Implement approval workflow for large amounts");
+
+    println!("\n=== Example Complete ===");
+}

--- a/alpaca-http/examples/http_transfers.rs
+++ b/alpaca-http/examples/http_transfers.rs
@@ -1,0 +1,126 @@
+//! # Transfers
+//!
+//! This example demonstrates how to create and manage fund transfers
+//! for broker accounts using the Alpaca Broker API.
+//!
+//! ## Prerequisites
+//!
+//! Set environment variables:
+//! - `ALPACA_API_KEY`: Your Alpaca Broker API key
+//! - `ALPACA_API_SECRET`: Your Alpaca Broker secret key
+//!
+//! ## Usage
+//!
+//! ```bash
+//! cargo run -p alpaca-http --example http_transfers
+//! ```
+//!
+//! **Note**: This example demonstrates the API structure. Broker API
+//! requires special credentials.
+
+fn main() {
+    println!("=== Transfers ===\n");
+
+    // Transfer types
+    println!("--- Transfer Types ---");
+    println!("  ACH: Bank transfer via ACH network (1-3 business days)");
+    println!("  WIRE: Wire transfer (same day, higher fees)");
+    println!("  INTERNAL: Transfer between Alpaca accounts");
+
+    // Transfer directions
+    println!("\n--- Transfer Directions ---");
+    println!("  INCOMING: Deposit funds into trading account");
+    println!("  OUTGOING: Withdraw funds from trading account");
+
+    // Create ACH transfer (deposit)
+    println!("\n--- Create ACH Deposit ---");
+    println!("  let request = CreateTransferRequest {{");
+    println!("      transfer_type: TransferType::Ach,");
+    println!("      relationship_id: \"ach-relationship-uuid\".to_string(),");
+    println!("      amount: \"1000.00\".to_string(),");
+    println!("      direction: TransferDirection::Incoming,");
+    println!("  }};");
+    println!("  let transfer = client.create_transfer(&account_id, &request).await?;");
+
+    // Create ACH transfer (withdrawal)
+    println!("\n--- Create ACH Withdrawal ---");
+    println!("  let request = CreateTransferRequest {{");
+    println!("      transfer_type: TransferType::Ach,");
+    println!("      relationship_id: \"ach-relationship-uuid\".to_string(),");
+    println!("      amount: \"500.00\".to_string(),");
+    println!("      direction: TransferDirection::Outgoing,");
+    println!("  }};");
+    println!("  let transfer = client.create_transfer(&account_id, &request).await?;");
+
+    // Transfer states
+    println!("\n--- Transfer States ---");
+    println!("  QUEUED: Transfer queued for processing");
+    println!("  PENDING: Transfer in progress");
+    println!("  SENT_TO_CLEARING: Sent to clearing house");
+    println!("  COMPLETE: Transfer completed successfully");
+    println!("  CANCELED: Transfer canceled");
+    println!("  RETURNED: Transfer returned (e.g., NSF)");
+    println!("  REJECTED: Transfer rejected");
+
+    // List transfers
+    println!("\n--- List Transfers ---");
+    println!("  let params = ListTransfersParams::new()");
+    println!("      .direction(TransferDirection::Incoming)");
+    println!("      .limit(50);");
+    println!("  let transfers = client.list_transfers(&account_id, &params).await?;");
+    println!("  for transfer in transfers {{");
+    println!(
+        "      println!(\"{{}} - ${{}} {{:?}}\", transfer.id, transfer.amount, transfer.status);"
+    );
+    println!("  }}");
+
+    // Get single transfer
+    println!("\n--- Get Transfer ---");
+    println!("  let transfer = client.get_transfer(&account_id, &transfer_id).await?;");
+    println!("  println!(\"Amount: ${{}}\", transfer.amount);");
+    println!("  println!(\"Status: {{:?}}\", transfer.status);");
+    println!("  println!(\"Created: {{}}\", transfer.created_at);");
+
+    // Cancel transfer
+    println!("\n--- Cancel Transfer ---");
+    println!("  client.cancel_transfer(&account_id, &transfer_id).await?;");
+    println!("  Note: Only QUEUED or PENDING transfers can be canceled");
+
+    // Transfer timing
+    println!("\n--- Transfer Timing ---");
+    println!("  ACH Deposits:");
+    println!("    - Standard: 3-5 business days");
+    println!("    - Same-day ACH: 1 business day (if supported)");
+    println!();
+    println!("  ACH Withdrawals:");
+    println!("    - Standard: 3-5 business days");
+    println!();
+    println!("  Wire Transfers:");
+    println!("    - Incoming: Same day (before cutoff)");
+    println!("    - Outgoing: Same day (before cutoff)");
+
+    // Instant deposits
+    println!("\n--- Instant Deposits ---");
+    println!("  Some accounts may have instant deposit enabled:");
+    println!("  - Funds available immediately for trading");
+    println!("  - Subject to limits based on account history");
+    println!("  - ACH still settles in background");
+
+    // Error handling
+    println!("\n--- Common Errors ---");
+    println!("  insufficient_funds: Not enough balance for withdrawal");
+    println!("  invalid_amount: Amount must be positive");
+    println!("  relationship_not_approved: ACH not yet verified");
+    println!("  transfer_limit_exceeded: Daily/monthly limit reached");
+    println!("  account_restricted: Account has trading restrictions");
+
+    // Best practices
+    println!("\n--- Best Practices ---");
+    println!("1. Validate amounts before submission");
+    println!("2. Show estimated completion dates to users");
+    println!("3. Implement webhooks for transfer status updates");
+    println!("4. Keep audit trail of all transfers");
+    println!("5. Set appropriate daily/monthly limits");
+
+    println!("\n=== Example Complete ===");
+}


### PR DESCRIPTION
Add 7 examples for alpaca-http Broker API:

- http_create_broker_account.rs: Create broker accounts
- http_get_broker_account.rs: Get and list broker accounts
- http_ach_relationships.rs: Manage ACH funding
- http_transfers.rs: Create and manage transfers
- http_journals.rs: Create journal entries
- http_documents.rs: List and retrieve documents
- http_ira_contributions.rs: Manage IRA contributions

Also:
- Update alpaca-http README with examples tables (Trading, Market Data, Broker API)

Closes #55