### PR TITLE
feat(examples): implement HTTP Specialty examples (E009)

### DIFF
--- a/alpaca-http/README.md
+++ b/alpaca-http/README.md
@@ -88,6 +88,16 @@ Run examples with `cargo run -p alpaca-http --example <name>`:
 | `http_documents` | List and retrieve documents |
 | `http_ira_contributions` | Manage IRA contributions |
 
+### Specialty Examples
+
+| Example | Description |
+|---------|-------------|
+| `http_news` | Fetch market news |
+| `http_exchange_rates` | Get FX exchange rates |
+| `http_market_clock` | Check market open/close status |
+| `http_trading_calendar` | Get trading calendar |
+| `http_corporate_actions` | List corporate actions |
+
 ## Contribution and Contact
 
 We welcome contributions to this project! If you would like to contribute, please follow these steps:

--- a/alpaca-http/examples/http_corporate_actions.rs
+++ b/alpaca-http/examples/http_corporate_actions.rs
@@ -1,0 +1,128 @@
+//! # Corporate Actions
+//!
+//! This example demonstrates how to list corporate actions
+//! using the Alpaca HTTP API.
+//!
+//! ## Prerequisites
+//!
+//! Set environment variables:
+//! - `ALPACA_API_KEY`: Your Alpaca API key
+//! - `ALPACA_API_SECRET`: Your Alpaca secret key
+//!
+//! ## Usage
+//!
+//! ```bash
+//! cargo run -p alpaca-http --example http_corporate_actions
+//! ```
+
+use alpaca_base::CorporateActionsParams;
+
+fn main() {
+    println!("=== Corporate Actions ===\n");
+
+    // Get corporate actions
+    println!("--- Get Corporate Actions ---");
+    let params = CorporateActionsParams::new()
+        .symbols("AAPL,MSFT,GOOGL")
+        .date_range("2024-01-01", "2024-12-31")
+        .limit(50);
+
+    println!("  Parameters:");
+    println!("    Symbols: {:?}", params.symbols);
+    println!("    Start: {:?}", params.start);
+    println!("    End: {:?}", params.end);
+    println!("    Limit: {:?}", params.limit);
+
+    println!("\n  API call:");
+    println!("    let response = client.get_corporate_actions(&params).await?;");
+    println!("    for action in response.corporate_actions {{");
+    println!("        println!(\"{{:?}} - {{}}\", action.action_type, action.symbol);");
+    println!("    }}");
+
+    // Filter by action type
+    println!("\n--- Filter by Action Type ---");
+    let dividend_params = CorporateActionsParams::new()
+        .types("dividend")
+        .symbols("AAPL");
+
+    println!("  Dividend filter:");
+    println!("    Types: {:?}", dividend_params.types);
+
+    // Corporate action types
+    println!("\n--- Corporate Action Types ---");
+    println!("  dividend: Cash dividend payment");
+    println!("  split: Stock split (forward or reverse)");
+    println!("  merger: Company merger");
+    println!("  spinoff: Company spinoff");
+    println!("  acquisition: Company acquisition");
+    println!("  rights_issue: Rights offering");
+    println!("  reorganization: Corporate reorganization");
+
+    // Corporate action fields
+    println!("\n--- Corporate Action Fields ---");
+    println!("  id: Unique identifier");
+    println!("  action_type: Type of corporate action");
+    println!("  sub_type: Sub-type (e.g., cash dividend, stock dividend)");
+    println!("  symbol: Stock symbol");
+    println!("  initiating_symbol: Original symbol (for mergers)");
+    println!("  target_symbol: Target symbol (for mergers)");
+    println!("  declaration_date: When action was announced");
+    println!("  ex_date: Ex-dividend/ex-distribution date");
+    println!("  record_date: Record date for eligibility");
+    println!("  payable_date: Payment date");
+    println!("  cash: Cash amount per share");
+    println!("  old_rate: Old share ratio (for splits)");
+    println!("  new_rate: New share ratio (for splits)");
+
+    // Dividend example
+    println!("\n--- Dividend Example ---");
+    println!("  action_type: dividend");
+    println!("  sub_type: cash");
+    println!("  symbol: AAPL");
+    println!("  declaration_date: 2024-02-01");
+    println!("  ex_date: 2024-02-09");
+    println!("  record_date: 2024-02-12");
+    println!("  payable_date: 2024-02-15");
+    println!("  cash: 0.24");
+
+    // Stock split example
+    println!("\n--- Stock Split Example ---");
+    println!("  action_type: split");
+    println!("  sub_type: forward");
+    println!("  symbol: NVDA");
+    println!("  ex_date: 2024-06-10");
+    println!("  old_rate: 1");
+    println!("  new_rate: 10");
+    println!("  (10-for-1 split: each share becomes 10 shares)");
+
+    // Pagination
+    println!("\n--- Pagination ---");
+    println!("  let mut page_token: Option<String> = None;");
+    println!("  loop {{");
+    println!("      let params = CorporateActionsParams::new()");
+    println!("          .limit(100)");
+    println!("          .page_token(page_token.as_deref().unwrap_or(\"\"));");
+    println!("      let response = client.get_corporate_actions(&params).await?;");
+    println!("      // Process actions...");
+    println!("      page_token = response.next_page_token;");
+    println!("      if page_token.is_none() {{ break; }}");
+    println!("  }}");
+
+    // Use cases
+    println!("\n--- Use Cases ---");
+    println!("1. Track dividend income");
+    println!("2. Adjust historical prices for splits");
+    println!("3. Monitor merger/acquisition activity");
+    println!("4. Calculate total shareholder return");
+    println!("5. Update portfolio for corporate events");
+
+    // Best practices
+    println!("\n--- Best Practices ---");
+    println!("1. Monitor ex-dates for dividend capture");
+    println!("2. Adjust position sizes after splits");
+    println!("3. Track record dates for eligibility");
+    println!("4. Handle symbol changes in mergers");
+    println!("5. Cache historical actions for backtesting");
+
+    println!("\n=== Example Complete ===");
+}

--- a/alpaca-http/examples/http_exchange_rates.rs
+++ b/alpaca-http/examples/http_exchange_rates.rs
@@ -1,0 +1,97 @@
+//! # Exchange Rates
+//!
+//! This example demonstrates how to get FX exchange rates
+//! using the Alpaca HTTP API.
+//!
+//! ## Prerequisites
+//!
+//! Set environment variables:
+//! - `ALPACA_API_KEY`: Your Alpaca API key
+//! - `ALPACA_API_SECRET`: Your Alpaca secret key
+//!
+//! ## Usage
+//!
+//! ```bash
+//! cargo run -p alpaca-http --example http_exchange_rates
+//! ```
+
+use alpaca_base::{Currency, ExchangeRate};
+
+fn main() {
+    println!("=== Exchange Rates ===\n");
+
+    // Get all exchange rates
+    println!("--- Get All Exchange Rates ---");
+    println!("  let rates = client.get_exchange_rates().await?;");
+    println!("  for rate in rates {{");
+    println!("      println!(\"{{:?}}/{{:?}}: {{}}\", rate.base, rate.quote, rate.rate);");
+    println!("  }}");
+
+    // Get specific currency pair
+    println!("\n--- Get Specific Currency Pair ---");
+    println!("  let rate = client.get_exchange_rate(\"EURUSD\").await?;");
+    println!("  println!(\"EUR/USD: {{}}\", rate.rate);");
+
+    // Common currency pairs
+    println!("\n--- Common Currency Pairs ---");
+    let pairs = [
+        ("EURUSD", "Euro to US Dollar"),
+        ("GBPUSD", "British Pound to US Dollar"),
+        ("USDJPY", "US Dollar to Japanese Yen"),
+        ("USDCAD", "US Dollar to Canadian Dollar"),
+        ("AUDUSD", "Australian Dollar to US Dollar"),
+        ("USDCHF", "US Dollar to Swiss Franc"),
+    ];
+
+    for (pair, description) in pairs {
+        println!("  {}: {}", pair, description);
+    }
+
+    // Currency conversion example
+    println!("\n--- Currency Conversion ---");
+    let rate = ExchangeRate::new(Currency::Eur, Currency::Usd, 1.10);
+    let amount_eur = 100.0;
+    let amount_usd = rate.convert(amount_eur);
+
+    println!("  Example rate: EUR/USD = {}", rate.rate);
+    println!("  Convert {} EUR to USD: {:.2} USD", amount_eur, amount_usd);
+    println!("  Inverse rate (USD/EUR): {:.6}", rate.inverse());
+
+    // Available currencies
+    println!("\n--- Available Currencies ---");
+    println!("  USD: US Dollar");
+    println!("  EUR: Euro");
+    println!("  GBP: British Pound");
+    println!("  JPY: Japanese Yen");
+    println!("  CAD: Canadian Dollar");
+    println!("  AUD: Australian Dollar");
+    println!("  CHF: Swiss Franc");
+    println!("  CNY: Chinese Yuan");
+    println!("  HKD: Hong Kong Dollar");
+    println!("  SGD: Singapore Dollar");
+
+    // Exchange rate fields
+    println!("\n--- Exchange Rate Fields ---");
+    println!("  base: Base currency");
+    println!("  quote: Quote currency");
+    println!("  rate: Exchange rate value");
+    println!("  timestamp: Rate timestamp");
+
+    // Use cases
+    println!("\n--- Use Cases ---");
+    println!("1. Convert international stock prices");
+    println!("2. Calculate portfolio value in home currency");
+    println!("3. Analyze currency exposure");
+    println!("4. FX trading strategies");
+    println!("5. International transaction calculations");
+
+    // Best practices
+    println!("\n--- Best Practices ---");
+    println!("1. Cache rates with reasonable TTL");
+    println!("2. Handle rate staleness gracefully");
+    println!("3. Use mid-market rates for estimates");
+    println!("4. Consider bid/ask spread for actual trades");
+    println!("5. Log rate timestamps for audit trails");
+
+    println!("\n=== Example Complete ===");
+}

--- a/alpaca-http/examples/http_market_clock.rs
+++ b/alpaca-http/examples/http_market_clock.rs
@@ -1,0 +1,106 @@
+//! # Market Clock
+//!
+//! This example demonstrates how to check market open/close status
+//! using the Alpaca HTTP API.
+//!
+//! ## Prerequisites
+//!
+//! Set environment variables:
+//! - `ALPACA_API_KEY`: Your Alpaca API key
+//! - `ALPACA_API_SECRET`: Your Alpaca secret key
+//!
+//! ## Usage
+//!
+//! ```bash
+//! cargo run -p alpaca-http --example http_market_clock
+//! ```
+
+fn main() {
+    println!("=== Market Clock ===\n");
+
+    // Get market clock
+    println!("--- Get Market Clock ---");
+    println!("  let clock = client.get_clock().await?;");
+    println!("  println!(\"Market is open: {{}}\", clock.is_open);");
+    println!("  println!(\"Next open: {{}}\", clock.next_open);");
+    println!("  println!(\"Next close: {{}}\", clock.next_close);");
+
+    // Clock fields
+    println!("\n--- Clock Fields ---");
+    println!("  timestamp: Current server time (UTC)");
+    println!("  is_open: Whether the market is currently open");
+    println!("  next_open: Next market open time (UTC)");
+    println!("  next_close: Next market close time (UTC)");
+
+    // Market hours
+    println!("\n--- US Market Hours (Eastern Time) ---");
+    println!("  Pre-market:    4:00 AM - 9:30 AM ET");
+    println!("  Regular:       9:30 AM - 4:00 PM ET");
+    println!("  After-hours:   4:00 PM - 8:00 PM ET");
+
+    // Market sessions
+    println!("\n--- Market Sessions ---");
+    println!("  PRE_MARKET: Extended hours before regular session");
+    println!("  REGULAR: Standard trading hours");
+    println!("  AFTER_HOURS: Extended hours after regular session");
+    println!("  CLOSED: Market is closed");
+
+    // Check if market is open
+    println!("\n--- Check Market Status ---");
+    println!("  if clock.is_open {{");
+    println!("      println!(\"Market is OPEN - trading allowed\");");
+    println!("      println!(\"Closes at: {{}}\", clock.next_close);");
+    println!("  }} else {{");
+    println!("      println!(\"Market is CLOSED\");");
+    println!("      println!(\"Opens at: {{}}\", clock.next_open);");
+    println!("  }}");
+
+    // Time until open/close
+    println!("\n--- Calculate Time Until Open/Close ---");
+    println!("  let now = Utc::now();");
+    println!("  if clock.is_open {{");
+    println!("      let until_close = clock.next_close - now;");
+    println!("      println!(\"Time until close: {{}} minutes\", until_close.num_minutes());");
+    println!("  }} else {{");
+    println!("      let until_open = clock.next_open - now;");
+    println!("      println!(\"Time until open: {{}} minutes\", until_open.num_minutes());");
+    println!("  }}");
+
+    // Market holidays
+    println!("\n--- Market Holidays (US) ---");
+    println!("  New Year's Day");
+    println!("  Martin Luther King Jr. Day");
+    println!("  Presidents' Day");
+    println!("  Good Friday");
+    println!("  Memorial Day");
+    println!("  Juneteenth");
+    println!("  Independence Day");
+    println!("  Labor Day");
+    println!("  Thanksgiving Day");
+    println!("  Christmas Day");
+
+    // Early close days
+    println!("\n--- Early Close Days ---");
+    println!("  Day before Independence Day (if weekday)");
+    println!("  Day after Thanksgiving");
+    println!("  Christmas Eve (if weekday)");
+    println!("  Market closes at 1:00 PM ET on these days");
+
+    // Use cases
+    println!("\n--- Use Cases ---");
+    println!("1. Schedule order submissions");
+    println!("2. Display market status in UI");
+    println!("3. Trigger alerts before market open/close");
+    println!("4. Prevent orders during closed hours");
+    println!("5. Plan trading sessions");
+
+    // Best practices
+    println!("\n--- Best Practices ---");
+    println!("1. Cache clock data with short TTL (1-5 minutes)");
+    println!("2. Use server timestamp, not local time");
+    println!("3. Handle timezone conversions carefully");
+    println!("4. Check clock before submitting orders");
+    println!("5. Account for extended hours trading");
+
+    println!("\n=== Example Complete ===");
+}

--- a/alpaca-http/examples/http_news.rs
+++ b/alpaca-http/examples/http_news.rs
@@ -1,0 +1,131 @@
+//! # Market News
+//!
+//! This example demonstrates how to fetch market news
+//! using the Alpaca HTTP API.
+//!
+//! ## Prerequisites
+//!
+//! Set environment variables:
+//! - `ALPACA_API_KEY`: Your Alpaca API key
+//! - `ALPACA_API_SECRET`: Your Alpaca secret key
+//!
+//! ## Usage
+//!
+//! ```bash
+//! cargo run -p alpaca-http --example http_news
+//! ```
+
+use alpaca_base::NewsParams;
+
+fn main() {
+    println!("=== Market News ===\n");
+
+    // Basic news request
+    println!("--- Basic News Request ---");
+    println!("  let params = NewsParams::new().limit(10);");
+    println!("  let response = client.get_enhanced_news(&params).await?;");
+    println!("  for article in response.news {{");
+    println!("      println!(\"{{}} - {{}}\", article.headline, article.source);");
+    println!("  }}");
+
+    // News for specific symbols
+    println!("\n--- News for Specific Symbols ---");
+    let params = NewsParams::new()
+        .symbols("AAPL,MSFT,GOOGL")
+        .limit(5)
+        .sort_desc();
+
+    println!("  Filter parameters:");
+    println!("    Symbols: {:?}", params.symbols);
+    println!("    Limit: {:?}", params.limit);
+    println!("    Sort: {:?}", params.sort);
+
+    println!("\n  API call:");
+    println!("    let response = client.get_enhanced_news_for_symbols(\"AAPL,MSFT\", 10).await?;");
+
+    // News with content
+    println!("\n--- News with Full Content ---");
+    let params_with_content = NewsParams::new()
+        .symbols("TSLA")
+        .with_content()
+        .exclude_empty()
+        .limit(3);
+
+    println!("  Parameters:");
+    println!(
+        "    Include content: {:?}",
+        params_with_content.include_content
+    );
+    println!(
+        "    Exclude contentless: {:?}",
+        params_with_content.exclude_contentless
+    );
+
+    // News by time range
+    println!("\n--- News by Time Range ---");
+    let params_time = NewsParams::new()
+        .time_range("2024-01-01T00:00:00Z", "2024-01-31T23:59:59Z")
+        .sort_asc();
+
+    println!("  Time range:");
+    println!("    Start: {:?}", params_time.start);
+    println!("    End: {:?}", params_time.end);
+    println!("    Sort: {:?}", params_time.sort);
+
+    // Latest news shortcut
+    println!("\n--- Latest News Shortcut ---");
+    println!("  let response = client.get_latest_enhanced_news(20).await?;");
+
+    // News article fields
+    println!("\n--- News Article Fields ---");
+    println!("  id: Unique article identifier");
+    println!("  headline: Article headline");
+    println!("  author: Article author");
+    println!("  source: News source (e.g., Benzinga, Reuters)");
+    println!("  summary: Brief summary");
+    println!("  content: Full article content (if requested)");
+    println!("  url: Link to original article");
+    println!("  symbols: Related stock symbols");
+    println!("  created_at: Publication timestamp");
+    println!("  updated_at: Last update timestamp");
+    println!("  images: Associated images");
+
+    // Pagination
+    println!("\n--- Pagination ---");
+    println!("  let mut page_token: Option<String> = None;");
+    println!("  loop {{");
+    println!("      let params = NewsParams::new()");
+    println!("          .limit(50)");
+    println!("          .page_token(page_token.as_deref().unwrap_or(\"\"));");
+    println!("      let response = client.get_enhanced_news(&params).await?;");
+    println!("      // Process articles...");
+    println!("      page_token = response.next_page_token;");
+    println!("      if page_token.is_none() {{ break; }}");
+    println!("  }}");
+
+    // News sources
+    println!("\n--- Common News Sources ---");
+    println!("  Benzinga: Real-time market news");
+    println!("  Reuters: Global news agency");
+    println!("  Bloomberg: Financial news");
+    println!("  Dow Jones: Business news");
+    println!("  PR Newswire: Press releases");
+
+    // Use cases
+    println!("\n--- Use Cases ---");
+    println!("1. Sentiment analysis on news headlines");
+    println!("2. Event-driven trading strategies");
+    println!("3. Portfolio monitoring alerts");
+    println!("4. Research and due diligence");
+    println!("5. News aggregation dashboards");
+
+    // Best practices
+    println!("\n--- Best Practices ---");
+    println!("1. Cache news to reduce API calls");
+    println!("2. Use symbol filters for relevant news");
+    println!("3. Implement rate limiting");
+    println!("4. Parse timestamps consistently");
+    println!("5. Handle missing content gracefully");
+
+    println!("\n=== Example Complete ===");
+}

--- a/alpaca-http/examples/http_trading_calendar.rs
+++ b/alpaca-http/examples/http_trading_calendar.rs
@@ -1,0 +1,120 @@
+//! # Trading Calendar
+//!
+//! This example demonstrates how to get the trading calendar
+//! using the Alpaca HTTP API.
+//!
+//! ## Prerequisites
+//!
+//! Set environment variables:
+//! - `ALPACA_API_KEY`: Your Alpaca API key
+//! - `ALPACA_API_SECRET`: Your Alpaca secret key
+//!
+//! ## Usage
+//!
+//! ```bash
+//! cargo run -p alpaca-http --example http_trading_calendar
+//! ```
+
+use alpaca_base::CalendarParams;
+
+fn main() {
+    println!("=== Trading Calendar ===\n");
+
+    // Get calendar for date range
+    println!("--- Get Calendar for Date Range ---");
+    let params = CalendarParams::new().start("2024-01-01").end("2024-01-31");
+
+    println!("  Parameters:");
+    println!("    Start: {:?}", params.start);
+    println!("    End: {:?}", params.end);
+
+    println!("\n  API call:");
+    println!("    let calendar = client.get_calendar(&params).await?;");
+    println!("    for day in calendar {{");
+    println!(
+        "        println!(\"{{}} - Open: {{}}, Close: {{}}\", day.date, day.open, day.close);"
+    );
+    println!("    }}");
+
+    // Calendar day fields
+    println!("\n--- Calendar Day Fields ---");
+    println!("  date: Trading date (YYYY-MM-DD)");
+    println!("  open: Market open time (HH:MM)");
+    println!("  close: Market close time (HH:MM)");
+    println!("  session_open: Extended hours open time");
+    println!("  session_close: Extended hours close time");
+
+    // Get current month
+    println!("\n--- Get Current Month ---");
+    println!("  let now = Utc::now();");
+    println!("  let start = now.format(\"%Y-%m-01\").to_string();");
+    println!("  let end = now.format(\"%Y-%m-31\").to_string();");
+    println!("  let params = CalendarParams::new().start(&start).end(&end);");
+    println!("  let calendar = client.get_calendar(&params).await?;");
+
+    // Count trading days
+    println!("\n--- Count Trading Days ---");
+    println!("  let params = CalendarParams::new()");
+    println!("      .start(\"2024-01-01\")");
+    println!("      .end(\"2024-12-31\");");
+    println!("  let calendar = client.get_calendar(&params).await?;");
+    println!("  println!(\"Trading days in 2024: {{}}\", calendar.len());");
+
+    // Find next trading day
+    println!("\n--- Find Next Trading Day ---");
+    println!("  let today = Utc::now().format(\"%Y-%m-%d\").to_string();");
+    println!("  let params = CalendarParams::new()");
+    println!("      .start(&today)");
+    println!("      .end(&next_week);");
+    println!("  let calendar = client.get_calendar(&params).await?;");
+    println!("  if let Some(next) = calendar.first() {{");
+    println!("      println!(\"Next trading day: {{}}\", next.date);");
+    println!("  }}");
+
+    // Check if specific date is trading day
+    println!("\n--- Check if Date is Trading Day ---");
+    println!("  let date = \"2024-07-04\"; // Independence Day");
+    println!("  let params = CalendarParams::new().start(date).end(date);");
+    println!("  let calendar = client.get_calendar(&params).await?;");
+    println!("  if calendar.is_empty() {{");
+    println!("      println!(\"{{}} is NOT a trading day\", date);");
+    println!("  }} else {{");
+    println!("      println!(\"{{}} IS a trading day\", date);");
+    println!("  }}");
+
+    // Early close detection
+    println!("\n--- Detect Early Close Days ---");
+    println!("  for day in calendar {{");
+    println!("      if day.close != \"16:00\" {{");
+    println!("          println!(\"Early close on {{}}: {{}}\", day.date, day.close);");
+    println!("      }}");
+    println!("  }}");
+
+    // Trading hours by day type
+    println!("\n--- Trading Hours by Day Type ---");
+    println!("  Regular Day:");
+    println!("    Open: 09:30 ET");
+    println!("    Close: 16:00 ET");
+    println!();
+    println!("  Early Close Day:");
+    println!("    Open: 09:30 ET");
+    println!("    Close: 13:00 ET");
+
+    // Use cases
+    println!("\n--- Use Cases ---");
+    println!("1. Schedule automated trading strategies");
+    println!("2. Calculate business days for settlement");
+    println!("3. Plan vacation around market closures");
+    println!("4. Build trading day countdown timers");
+    println!("5. Validate order scheduling");
+
+    // Best practices
+    println!("\n--- Best Practices ---");
+    println!("1. Cache calendar data (changes infrequently)");
+    println!("2. Refresh cache at start of each year");
+    println!("3. Handle edge cases (early close days)");
+    println!("4. Use calendar for backtesting date ranges");
+    println!("5. Combine with clock for real-time status");
+
+    println!("\n=== Example Complete ===");
+}


### PR DESCRIPTION
Add 5 examples for alpaca-http Specialty endpoints:

- http_news.rs: Fetch market news
- http_exchange_rates.rs: Get FX exchange rates
- http_market_clock.rs: Check market open/close status
- http_trading_calendar.rs: Get trading calendar
- http_corporate_actions.rs: List corporate actions

Also:
- Update alpaca-http README with Specialty examples section

Closes #56