### PR TITLE
feat(examples): implement FIX Connection & Trading examples (E010)

### DIFF
--- a/alpaca-fix/README.md
+++ b/alpaca-fix/README.md
@@ -35,6 +35,8 @@ alpaca-fix = "0.2.0"
 
 Run examples with `cargo run -p alpaca-fix --example <name>`:
 
+### Session & Message Examples
+
 | Example | Description |
 |---------|-------------|
 | `fix_session_setup` | Configure and set up a FIX session |
@@ -42,6 +44,19 @@ Run examples with `cargo run -p alpaca-fix --example <name>`:
 | `fix_order_cancel` | Create Cancel and Cancel/Replace messages |
 | `fix_execution_report` | Execution Report message structure |
 | `fix_market_data_request` | Market Data Request messages |
+
+### Connection & Trading Examples
+
+| Example | Description |
+|---------|-------------|
+| `fix_connect` | Connect to FIX server |
+| `fix_disconnect` | Graceful disconnect |
+| `fix_market_order` | Send market order via FIX |
+| `fix_limit_order` | Send limit order via FIX |
+| `fix_cancel_order` | Cancel order via FIX |
+| `fix_execution_reports` | Process execution reports |
+| `fix_heartbeat` | Heartbeat handling |
+| `fix_message_loop` | Receive and process messages |
 
 ```bash
 # Session setup example

--- a/alpaca-fix/examples/fix_cancel_order.rs
+++ b/alpaca-fix/examples/fix_cancel_order.rs
@@ -1,0 +1,116 @@
+//! # FIX Cancel Order
+//!
+//! This example demonstrates how to cancel an order via FIX protocol
+//! using the Alpaca FIX client.
+//!
+//! ## Prerequisites
+//!
+//! Set environment variables:
+//! - `ALPACA_API_KEY`: Your Alpaca API key
+//! - `ALPACA_API_SECRET`: Your Alpaca secret key
+//!
+//! ## Usage
+//!
+//! ```bash
+//! cargo run -p alpaca-fix --example fix_cancel_order
+//! ```
+//!
+//! **Note**: This example demonstrates the API structure. FIX connections
+//! require special credentials and server access.
+
+use alpaca_fix::messages::{OrderCancelRequest, Side};
+
+fn main() {
+    println!("=== FIX Cancel Order ===\n");
+
+    // Create cancel request
+    println!("--- Create Cancel Request ---");
+    let cancel = OrderCancelRequest::new(
+        "original-order-001", // Original client order ID
+        "AAPL",               // Symbol
+        Side::Buy,            // Original order side
+    );
+
+    println!("  Original ClOrdID: {}", cancel.orig_cl_ord_id);
+    println!("  Cancel ClOrdID: {}", cancel.cl_ord_id);
+    println!("  Symbol: {}", cancel.symbol);
+    println!("  Side: {:?}", cancel.side);
+
+    // Send cancel request
+    println!("\n--- Send Cancel Request ---");
+    println!("  let cl_ord_id = client.cancel_order(&cancel).await?;");
+    println!("  println!(\"Cancel request sent: {{}}\", cl_ord_id);");
+
+    // Order Cancel Request FIX fields
+    println!("\n--- Cancel Request FIX Fields ---");
+    println!("  MsgType (35): F (Order Cancel Request)");
+    println!("  OrigClOrdID (41): Original client order ID");
+    println!("  ClOrdID (11): New client order ID for cancel");
+    println!("  Symbol (55): Stock symbol");
+    println!("  Side (54): Original order side");
+    println!("  TransactTime (60): Transaction timestamp");
+
+    // Cancel response scenarios
+    println!("\n--- Cancel Response Scenarios ---");
+    println!("  1. Cancel Accepted:");
+    println!("     - ExecutionReport with ExecType=Canceled");
+    println!("     - OrdStatus=Canceled");
+    println!();
+    println!("  2. Cancel Rejected:");
+    println!("     - OrderCancelReject message");
+    println!("     - CxlRejReason indicates why");
+    println!();
+    println!("  3. Too Late to Cancel:");
+    println!("     - Order already filled");
+    println!("     - OrderCancelReject with reason");
+
+    // Handle cancel response
+    println!("\n--- Handle Cancel Response ---");
+    println!("  let msg = client.next_message().await?;");
+    println!("  if let Some(msg_type) = msg.msg_type() {{");
+    println!("      match msg_type {{");
+    println!("          \"8\" => {{ // ExecutionReport");
+    println!("              let report = client.parse_execution_report(&msg)?;");
+    println!("              if report.ord_status == OrdStatus::Canceled {{");
+    println!("                  println!(\"Order canceled successfully\");");
+    println!("              }}");
+    println!("          }}");
+    println!("          \"9\" => {{ // OrderCancelReject");
+    println!("              println!(\"Cancel rejected\");");
+    println!("              // Parse rejection reason");
+    println!("          }}");
+    println!("          _ => {{}}");
+    println!("      }}");
+    println!("  }}");
+
+    // Cancel rejection reasons
+    println!("\n--- Cancel Rejection Reasons ---");
+    println!("  0: Too late to cancel");
+    println!("  1: Unknown order");
+    println!("  2: Broker option");
+    println!("  3: Order already pending cancel");
+    println!("  4: Unable to process request");
+    println!("  5: OrigOrdModTime did not match");
+    println!("  6: Duplicate ClOrdID");
+
+    // Cancel vs Cancel/Replace
+    println!("\n--- Cancel vs Cancel/Replace ---");
+    println!("  Cancel (MsgType F):");
+    println!("    - Completely cancels the order");
+    println!("    - No replacement order");
+    println!();
+    println!("  Cancel/Replace (MsgType G):");
+    println!("    - Cancels and replaces with new order");
+    println!("    - Can modify price, quantity, etc.");
+    println!("    - Atomic operation");
+
+    // Best practices
+    println!("\n--- Best Practices ---");
+    println!("1. Use unique ClOrdID for each cancel request");
+    println!("2. Track original order ID accurately");
+    println!("3. Handle race conditions (fill vs cancel)");
+    println!("4. Implement timeout for cancel confirmation");
+    println!("5. Log all cancel attempts and responses");
+
+    println!("\n=== Example Complete ===");
+}

--- a/alpaca-fix/examples/fix_connect.rs
+++ b/alpaca-fix/examples/fix_connect.rs
@@ -1,0 +1,108 @@
+//! # FIX Connect
+//!
+//! This example demonstrates how to connect to a FIX server
+//! using the Alpaca FIX protocol client.
+//!
+//! ## Prerequisites
+//!
+//! Set environment variables:
+//! - `ALPACA_API_KEY`: Your Alpaca API key
+//! - `ALPACA_API_SECRET`: Your Alpaca secret key
+//!
+//! ## Usage
+//!
+//! ```bash
+//! cargo run -p alpaca-fix --example fix_connect
+//! ```
+//!
+//! **Note**: This example demonstrates the API structure. FIX connections
+//! require special credentials and server access.
+
+use alpaca_fix::{FixConfig, FixVersion};
+
+fn main() {
+    println!("=== FIX Connect ===\n");
+
+    // Create FIX configuration
+    println!("--- FIX Configuration ---");
+    let config = FixConfig::builder()
+        .version(FixVersion::Fix44)
+        .sender_comp_id("YOUR_SENDER_ID")
+        .target_comp_id("ALPACA")
+        .host("fix.alpaca.markets")
+        .port(5001)
+        .heartbeat_interval_secs(30)
+        .build();
+
+    println!("  FIX Version: {:?}", config.version);
+    println!("  Sender CompID: {}", config.sender_comp_id);
+    println!("  Target CompID: {}", config.target_comp_id);
+    println!("  Host: {}", config.host);
+    println!("  Port: {}", config.port);
+    println!("  Heartbeat Interval: {}s", config.heartbeat_interval_secs);
+
+    // Connection process
+    println!("\n--- Connection Process ---");
+    println!("  1. Create credentials from environment");
+    println!("     let credentials = Credentials::from_env()?;");
+    println!();
+    println!("  2. Create FIX client");
+    println!("     let client = FixClient::new(credentials, config);");
+    println!();
+    println!("  3. Connect to server");
+    println!("     client.connect().await?;");
+    println!();
+    println!("  4. Check session state");
+    println!("     let state = client.state().await;");
+    println!("     println!(\"Session state: {{:?}}\", state);");
+
+    // Session states
+    println!("\n--- Session States ---");
+    println!("  Disconnected: Not connected to server");
+    println!("  Connecting: TCP connection in progress");
+    println!("  LoggingOn: Sending logon message");
+    println!("  Active: Session established, ready for trading");
+    println!("  LoggingOut: Sending logout message");
+    println!("  Reconnecting: Attempting to reconnect");
+
+    // Logon message fields
+    println!("\n--- Logon Message Fields ---");
+    println!("  MsgType (35): A (Logon)");
+    println!("  SenderCompID (49): Your sender ID");
+    println!("  TargetCompID (56): ALPACA");
+    println!("  MsgSeqNum (34): Message sequence number");
+    println!("  SendingTime (52): UTC timestamp");
+    println!("  EncryptMethod (98): 0 (None)");
+    println!("  HeartBtInt (108): Heartbeat interval in seconds");
+    println!("  Username (553): API key");
+    println!("  Password (554): API secret");
+
+    // Configuration options
+    println!("\n--- Configuration Options ---");
+    println!("  version: FIX 4.2 or FIX 4.4");
+    println!("  sender_comp_id: Your unique identifier");
+    println!("  target_comp_id: Server identifier (ALPACA)");
+    println!("  host: FIX server hostname");
+    println!("  port: FIX server port");
+    println!("  heartbeat_interval_secs: Heartbeat frequency");
+    println!("  reconnect_enabled: Auto-reconnect on disconnect");
+    println!("  max_reconnect_attempts: Max reconnection tries");
+    println!("  log_messages: Enable message logging");
+
+    // Error handling
+    println!("\n--- Connection Errors ---");
+    println!("  Connection refused: Server not available");
+    println!("  Authentication failed: Invalid credentials");
+    println!("  Timeout: Server not responding");
+    println!("  Sequence gap: Message sequence mismatch");
+
+    // Best practices
+    println!("\n--- Best Practices ---");
+    println!("1. Use environment variables for credentials");
+    println!("2. Set appropriate heartbeat interval (30s typical)");
+    println!("3. Implement reconnection logic");
+    println!("4. Log all FIX messages for debugging");
+    println!("5. Handle session state changes");
+
+    println!("\n=== Example Complete ===");
+}

--- a/alpaca-fix/examples/fix_disconnect.rs
+++ b/alpaca-fix/examples/fix_disconnect.rs
@@ -1,0 +1,105 @@
+//! # FIX Disconnect
+//!
+//! This example demonstrates how to gracefully disconnect from a FIX server
+//! using the Alpaca FIX protocol client.
+//!
+//! ## Prerequisites
+//!
+//! Set environment variables:
+//! - `ALPACA_API_KEY`: Your Alpaca API key
+//! - `ALPACA_API_SECRET`: Your Alpaca secret key
+//!
+//! ## Usage
+//!
+//! ```bash
+//! cargo run -p alpaca-fix --example fix_disconnect
+//! ```
+//!
+//! **Note**: This example demonstrates the API structure. FIX connections
+//! require special credentials and server access.
+
+fn main() {
+    println!("=== FIX Disconnect ===\n");
+
+    // Graceful disconnect process
+    println!("--- Graceful Disconnect ---");
+    println!("  1. Check current session state");
+    println!("     let state = client.state().await;");
+    println!("     if state == SessionState::Active {{");
+    println!();
+    println!("  2. Send logout message");
+    println!("     client.disconnect().await?;");
+    println!();
+    println!("  3. Wait for logout confirmation");
+    println!("     // Client waits up to 5 seconds for server response");
+    println!();
+    println!("  4. Close TCP connection");
+    println!("     // Connection is closed automatically");
+
+    // Logout message fields
+    println!("\n--- Logout Message Fields ---");
+    println!("  MsgType (35): 5 (Logout)");
+    println!("  SenderCompID (49): Your sender ID");
+    println!("  TargetCompID (56): ALPACA");
+    println!("  MsgSeqNum (34): Next sequence number");
+    println!("  SendingTime (52): UTC timestamp");
+    println!("  Text (58): Optional logout reason");
+
+    // Disconnect scenarios
+    println!("\n--- Disconnect Scenarios ---");
+    println!("  Normal logout:");
+    println!("    - Send Logout message");
+    println!("    - Receive Logout confirmation");
+    println!("    - Close connection");
+    println!();
+    println!("  Server-initiated logout:");
+    println!("    - Receive Logout from server");
+    println!("    - Send Logout response");
+    println!("    - Close connection");
+    println!();
+    println!("  Connection lost:");
+    println!("    - Detect TCP disconnect");
+    println!("    - Update session state");
+    println!("    - Optionally attempt reconnect");
+
+    // Session state transitions
+    println!("\n--- State Transitions on Disconnect ---");
+    println!("  Active -> LoggingOut -> Disconnected");
+    println!();
+    println!("  if client.state().await == SessionState::Active {{");
+    println!("      client.disconnect().await?;");
+    println!("      assert_eq!(client.state().await, SessionState::Disconnected);");
+    println!("  }}");
+
+    // Cleanup
+    println!("\n--- Cleanup Tasks ---");
+    println!("  1. Stop heartbeat background task");
+    println!("  2. Stop message receiver task");
+    println!("  3. Flush pending messages");
+    println!("  4. Close message channels");
+    println!("  5. Close TCP socket");
+
+    // Reconnection after disconnect
+    println!("\n--- Reconnection After Disconnect ---");
+    println!("  // After disconnect, you can reconnect");
+    println!("  client.disconnect().await?;");
+    println!("  // ... some time later ...");
+    println!("  client.connect().await?;");
+    println!("  // Session is re-established with new sequence numbers");
+
+    // Error handling
+    println!("\n--- Disconnect Errors ---");
+    println!("  Timeout: Server didn't respond to logout");
+    println!("  Already disconnected: Session not active");
+    println!("  Network error: Connection already broken");
+
+    // Best practices
+    println!("\n--- Best Practices ---");
+    println!("1. Always disconnect gracefully when possible");
+    println!("2. Handle server-initiated logouts");
+    println!("3. Implement shutdown hooks for clean exit");
+    println!("4. Log disconnect reasons for debugging");
+    println!("5. Reset state before reconnecting");
+
+    println!("\n=== Example Complete ===");
+}

--- a/alpaca-fix/examples/fix_execution_reports.rs
+++ b/alpaca-fix/examples/fix_execution_reports.rs
@@ -1,0 +1,150 @@
+//! # FIX Execution Reports
+//!
+//! This example demonstrates how to process execution reports via FIX protocol
+//! using the Alpaca FIX client.
+//!
+//! ## Prerequisites
+//!
+//! Set environment variables:
+//! - `ALPACA_API_KEY`: Your Alpaca API key
+//! - `ALPACA_API_SECRET`: Your Alpaca secret key
+//!
+//! ## Usage
+//!
+//! ```bash
+//! cargo run -p alpaca-fix --example fix_execution_reports
+//! ```
+//!
+//! **Note**: This example demonstrates the API structure. FIX connections
+//! require special credentials and server access.
+
+use alpaca_fix::messages::{ExecType, OrdStatus};
+
+fn main() {
+    println!("=== FIX Execution Reports ===\n");
+
+    // Execution report overview
+    println!("--- Execution Report Overview ---");
+    println!("  Execution reports (MsgType 8) provide order status updates.");
+    println!("  They are sent by the server in response to:");
+    println!("    - New orders");
+    println!("    - Order modifications");
+    println!("    - Order cancellations");
+    println!("    - Fills and partial fills");
+
+    // Parse execution report
+    println!("\n--- Parse Execution Report ---");
+    println!("  let msg = client.next_message().await?;");
+    println!("  if msg.msg_type() == Some(\"8\") {{");
+    println!("      let report = client.parse_execution_report(&msg)?;");
+    println!("      println!(\"Order ID: {{}}\", report.order_id);");
+    println!("      println!(\"Client Order ID: {{}}\", report.cl_ord_id);");
+    println!("      println!(\"Exec Type: {{:?}}\", report.exec_type);");
+    println!("      println!(\"Order Status: {{:?}}\", report.ord_status);");
+    println!("  }}");
+
+    // Execution report fields
+    println!("\n--- Execution Report Fields ---");
+    println!("  order_id: Server-assigned order ID");
+    println!("  cl_ord_id: Client order ID");
+    println!("  exec_id: Unique execution ID");
+    println!("  exec_type: Type of execution event");
+    println!("  ord_status: Current order status");
+    println!("  symbol: Stock symbol");
+    println!("  side: Buy or Sell");
+    println!("  order_qty: Total order quantity");
+    println!("  last_qty: Quantity of last fill");
+    println!("  last_px: Price of last fill");
+    println!("  cum_qty: Cumulative filled quantity");
+    println!("  avg_px: Average fill price");
+    println!("  leaves_qty: Remaining quantity");
+    println!("  text: Optional message text");
+
+    // Execution types
+    println!("\n--- Execution Types (ExecType) ---");
+    let exec_types = [
+        (ExecType::New, "Order accepted"),
+        (ExecType::PartialFill, "Partial fill occurred"),
+        (ExecType::Fill, "Order completely filled"),
+        (ExecType::Canceled, "Order canceled"),
+        (ExecType::Replaced, "Order replaced"),
+        (ExecType::PendingCancel, "Cancel pending"),
+        (ExecType::Rejected, "Order rejected"),
+        (ExecType::PendingNew, "New order pending"),
+        (ExecType::Expired, "Order expired"),
+    ];
+
+    for (exec_type, description) in exec_types {
+        println!("  {:?}: {}", exec_type, description);
+    }
+
+    // Order statuses
+    println!("\n--- Order Statuses (OrdStatus) ---");
+    let ord_statuses = [
+        (OrdStatus::New, "Order accepted, not yet filled"),
+        (OrdStatus::PartiallyFilled, "Partially filled"),
+        (OrdStatus::Filled, "Completely filled"),
+        (OrdStatus::Canceled, "Order canceled"),
+        (OrdStatus::Replaced, "Order replaced"),
+        (OrdStatus::PendingCancel, "Cancel request pending"),
+        (OrdStatus::Rejected, "Order rejected"),
+        (OrdStatus::PendingNew, "New order pending"),
+        (OrdStatus::Expired, "Order expired"),
+    ];
+
+    for (status, description) in ord_statuses {
+        println!("  {:?}: {}", status, description);
+    }
+
+    // Handle different execution types
+    println!("\n--- Handle Execution Types ---");
+    println!("  match report.exec_type {{");
+    println!("      ExecType::New => {{");
+    println!("          println!(\"Order accepted: {{}}\", report.order_id);");
+    println!("      }}");
+    println!("      ExecType::Fill => {{");
+    println!("          println!(\"Filled: {{}} @ {{}}\", report.cum_qty, report.avg_px);");
+    println!("      }}");
+    println!("      ExecType::PartialFill => {{");
+    println!("          let filled = report.last_qty.unwrap_or(0.0);");
+    println!("          let price = report.last_px.unwrap_or(0.0);");
+    println!("          println!(\"Partial: {{}} @ {{}}, remaining: {{}}\",");
+    println!("              filled, price, report.leaves_qty);");
+    println!("      }}");
+    println!("      ExecType::Canceled => {{");
+    println!("          println!(\"Canceled: {{}}\", report.cl_ord_id);");
+    println!("      }}");
+    println!("      ExecType::Rejected => {{");
+    println!("          println!(\"Rejected: {{:?}}\", report.text);");
+    println!("      }}");
+    println!("      _ => {{}}");
+    println!("  }}");
+
+    // FIX message tags
+    println!("\n--- Execution Report FIX Tags ---");
+    println!("  MsgType (35): 8");
+    println!("  OrderID (37): Server order ID");
+    println!("  ClOrdID (11): Client order ID");
+    println!("  ExecID (17): Execution ID");
+    println!("  ExecType (150): Execution type");
+    println!("  OrdStatus (39): Order status");
+    println!("  Symbol (55): Stock symbol");
+    println!("  Side (54): Order side");
+    println!("  OrderQty (38): Order quantity");
+    println!("  LastQty (32): Last fill quantity");
+    println!("  LastPx (31): Last fill price");
+    println!("  CumQty (14): Cumulative quantity");
+    println!("  AvgPx (6): Average price");
+    println!("  LeavesQty (151): Remaining quantity");
+    println!("  Text (58): Message text");
+
+    // Best practices
+    println!("\n--- Best Practices ---");
+    println!("1. Process all execution reports in order");
+    println!("2. Track order state transitions");
+    println!("3. Handle partial fills correctly");
+    println!("4. Store execution IDs for reconciliation");
+    println!("5. Log all execution reports");
+
+    println!("\n=== Example Complete ===");
+}

--- a/alpaca-fix/examples/fix_heartbeat.rs
+++ b/alpaca-fix/examples/fix_heartbeat.rs
@@ -1,0 +1,114 @@
+//! # FIX Heartbeat
+//!
+//! This example demonstrates heartbeat handling in FIX protocol
+//! using the Alpaca FIX client.
+//!
+//! ## Prerequisites
+//!
+//! Set environment variables:
+//! - `ALPACA_API_KEY`: Your Alpaca API key
+//! - `ALPACA_API_SECRET`: Your Alpaca secret key
+//!
+//! ## Usage
+//!
+//! ```bash
+//! cargo run -p alpaca-fix --example fix_heartbeat
+//! ```
+//!
+//! **Note**: This example demonstrates the API structure. FIX connections
+//! require special credentials and server access.
+
+fn main() {
+    println!("=== FIX Heartbeat ===\n");
+
+    // Heartbeat overview
+    println!("--- Heartbeat Overview ---");
+    println!("  Heartbeats maintain FIX session connectivity.");
+    println!("  They are exchanged at regular intervals to:");
+    println!("    - Verify connection is alive");
+    println!("    - Detect network failures");
+    println!("    - Prevent TCP timeouts");
+
+    // Heartbeat configuration
+    println!("\n--- Heartbeat Configuration ---");
+    println!("  let config = FixConfig::builder()");
+    println!("      .heartbeat_interval(30) // 30 seconds");
+    println!("      .build();");
+    println!();
+    println!("  Typical intervals: 30-60 seconds");
+    println!("  Negotiated during logon");
+
+    // Heartbeat message
+    println!("\n--- Heartbeat Message (MsgType 0) ---");
+    println!("  MsgType (35): 0 (Heartbeat)");
+    println!("  SenderCompID (49): Your sender ID");
+    println!("  TargetCompID (56): ALPACA");
+    println!("  MsgSeqNum (34): Sequence number");
+    println!("  SendingTime (52): UTC timestamp");
+    println!("  TestReqID (112): Optional, echoes TestRequest");
+
+    // Test request message
+    println!("\n--- Test Request Message (MsgType 1) ---");
+    println!("  Sent when no message received within heartbeat interval.");
+    println!("  MsgType (35): 1 (TestRequest)");
+    println!("  TestReqID (112): Unique identifier");
+    println!();
+    println!("  Response: Heartbeat with matching TestReqID");
+
+    // Automatic heartbeat handling
+    println!("\n--- Automatic Heartbeat Handling ---");
+    println!("  The FIX client handles heartbeats automatically:");
+    println!();
+    println!("  1. Background task sends heartbeats at configured interval");
+    println!("  2. Responds to TestRequest with Heartbeat");
+    println!("  3. Sends TestRequest if no message received");
+    println!("  4. Detects connection loss if no response");
+
+    // Heartbeat flow
+    println!("\n--- Heartbeat Flow ---");
+    println!("  Normal operation:");
+    println!("    Client -> Heartbeat -> Server");
+    println!("    Server -> Heartbeat -> Client");
+    println!();
+    println!("  Connection check:");
+    println!("    Client -> TestRequest (ID=123) -> Server");
+    println!("    Server -> Heartbeat (TestReqID=123) -> Client");
+
+    // Connection loss detection
+    println!("\n--- Connection Loss Detection ---");
+    println!("  If no message received within:");
+    println!("    HeartBtInt + reasonable transmission time");
+    println!();
+    println!("  Then:");
+    println!("    1. Send TestRequest");
+    println!("    2. Wait for Heartbeat response");
+    println!("    3. If no response, consider connection lost");
+    println!("    4. Initiate reconnection if configured");
+
+    // Manual heartbeat (if needed)
+    println!("\n--- Manual Heartbeat (Advanced) ---");
+    println!("  // Usually not needed - handled automatically");
+    println!("  // But available for custom implementations:");
+    println!("  let heartbeat = session.create_heartbeat(None);");
+    println!("  client.send_raw(&heartbeat).await?;");
+
+    // Logon heartbeat negotiation
+    println!("\n--- Logon Heartbeat Negotiation ---");
+    println!("  During logon, HeartBtInt (108) is exchanged:");
+    println!();
+    println!("  Client Logon:");
+    println!("    HeartBtInt=30 (proposed interval)");
+    println!();
+    println!("  Server Logon:");
+    println!("    HeartBtInt=30 (confirmed interval)");
+
+    // Best practices
+    println!("\n--- Best Practices ---");
+    println!("1. Use 30-second interval for most cases");
+    println!("2. Don't set interval too low (network overhead)");
+    println!("3. Don't set interval too high (slow failure detection)");
+    println!("4. Monitor heartbeat failures for connection issues");
+    println!("5. Implement reconnection on heartbeat timeout");
+
+    println!("\n=== Example Complete ===");
+}

--- a/alpaca-fix/examples/fix_limit_order.rs
+++ b/alpaca-fix/examples/fix_limit_order.rs
@@ -1,0 +1,121 @@
+//! # FIX Limit Order
+//!
+//! This example demonstrates how to send a limit order via FIX protocol
+//! using the Alpaca FIX client.
+//!
+//! ## Prerequisites
+//!
+//! Set environment variables:
+//! - `ALPACA_API_KEY`: Your Alpaca API key
+//! - `ALPACA_API_SECRET`: Your Alpaca secret key
+//!
+//! ## Usage
+//!
+//! ```bash
+//! cargo run -p alpaca-fix --example fix_limit_order
+//! ```
+//!
+//! **Note**: This example demonstrates the API structure. FIX connections
+//! require special credentials and server access.
+
+use alpaca_fix::messages::{NewOrderSingle, Side, TimeInForce};
+
+fn main() {
+    println!("=== FIX Limit Order ===\n");
+
+    // Create limit buy order
+    println!("--- Create Limit Buy Order ---");
+    let buy_order = NewOrderSingle::limit("AAPL", Side::Buy, 100.0, 150.00)
+        .with_cl_ord_id("limit-001")
+        .with_time_in_force(TimeInForce::Gtc);
+
+    println!("  Symbol: {}", buy_order.symbol);
+    println!("  Side: {:?}", buy_order.side);
+    println!("  Order Type: {:?}", buy_order.ord_type);
+    println!("  Quantity: {}", buy_order.order_qty);
+    println!("  Limit Price: {:?}", buy_order.price);
+    println!("  Time in Force: {:?}", buy_order.time_in_force);
+    println!("  Client Order ID: {}", buy_order.cl_ord_id);
+
+    // Create limit sell order
+    println!("\n--- Create Limit Sell Order ---");
+    let sell_order = NewOrderSingle::limit("MSFT", Side::Sell, 50.0, 400.00)
+        .with_cl_ord_id("limit-002")
+        .with_time_in_force(TimeInForce::Day);
+
+    println!("  Symbol: {}", sell_order.symbol);
+    println!("  Side: {:?}", sell_order.side);
+    println!("  Limit Price: {:?}", sell_order.price);
+
+    // Send order
+    println!("\n--- Send Order ---");
+    println!("  let cl_ord_id = client.send_order(&buy_order).await?;");
+    println!("  println!(\"Limit order sent: {{}}\", cl_ord_id);");
+
+    // New Order Single FIX fields for limit order
+    println!("\n--- Limit Order FIX Fields ---");
+    println!("  MsgType (35): D (New Order Single)");
+    println!("  ClOrdID (11): Client order ID");
+    println!("  Symbol (55): Stock symbol");
+    println!("  Side (54): 1=Buy, 2=Sell");
+    println!("  OrdType (40): 2=Limit");
+    println!("  Price (44): Limit price");
+    println!("  OrderQty (38): Order quantity");
+    println!("  TimeInForce (59): Order duration");
+    println!("  TransactTime (60): Transaction timestamp");
+
+    // Limit order characteristics
+    println!("\n--- Limit Order Characteristics ---");
+    println!("  - Executes only at specified price or better");
+    println!("  - Buy limit: executes at limit price or lower");
+    println!("  - Sell limit: executes at limit price or higher");
+    println!("  - May not fill if price not reached");
+    println!("  - Provides price certainty");
+
+    // Price improvement
+    println!("\n--- Price Improvement ---");
+    println!("  Limit orders may receive price improvement:");
+    println!("  - Buy at $150.00, filled at $149.95 = $0.05 improvement");
+    println!("  - Sell at $400.00, filled at $400.10 = $0.10 improvement");
+
+    // Partial fills
+    println!("\n--- Handling Partial Fills ---");
+    println!("  loop {{");
+    println!("      let msg = client.next_message().await?;");
+    println!("      let report = client.parse_execution_report(&msg)?;");
+    println!("      match report.exec_type {{");
+    println!("          ExecType::PartialFill => {{");
+    println!("              println!(\"Partial fill: {{}} @ {{}}\",");
+    println!("                  report.last_qty.unwrap_or(0.0),");
+    println!("                  report.last_px.unwrap_or(0.0));");
+    println!("              println!(\"Remaining: {{}}\", report.leaves_qty);");
+    println!("          }}");
+    println!("          ExecType::Fill => {{");
+    println!("              println!(\"Order filled completely\");");
+    println!("              break;");
+    println!("          }}");
+    println!("          _ => {{}}");
+    println!("      }}");
+    println!("  }}");
+
+    // GTC vs Day orders
+    println!("\n--- GTC vs Day Orders ---");
+    println!("  Day Order:");
+    println!("    - Expires at end of trading day");
+    println!("    - Automatically canceled if not filled");
+    println!();
+    println!("  GTC (Good Till Canceled):");
+    println!("    - Remains active until filled or canceled");
+    println!("    - May remain open for days/weeks");
+    println!("    - Check broker's GTC expiration policy");
+
+    // Best practices
+    println!("\n--- Best Practices ---");
+    println!("1. Set realistic limit prices");
+    println!("2. Consider bid-ask spread");
+    println!("3. Use GTC for longer-term strategies");
+    println!("4. Monitor unfilled orders");
+    println!("5. Cancel stale orders to free buying power");
+
+    println!("\n=== Example Complete ===");
+}

--- a/alpaca-fix/examples/fix_market_order.rs
+++ b/alpaca-fix/examples/fix_market_order.rs
@@ -1,0 +1,111 @@
+//! # FIX Market Order
+//!
+//! This example demonstrates how to send a market order via FIX protocol
+//! using the Alpaca FIX client.
+//!
+//! ## Prerequisites
+//!
+//! Set environment variables:
+//! - `ALPACA_API_KEY`: Your Alpaca API key
+//! - `ALPACA_API_SECRET`: Your Alpaca secret key
+//!
+//! ## Usage
+//!
+//! ```bash
+//! cargo run -p alpaca-fix --example fix_market_order
+//! ```
+//!
+//! **Note**: This example demonstrates the API structure. FIX connections
+//! require special credentials and server access.
+
+use alpaca_fix::messages::{NewOrderSingle, Side, TimeInForce};
+
+fn main() {
+    println!("=== FIX Market Order ===\n");
+
+    // Create market buy order
+    println!("--- Create Market Buy Order ---");
+    let buy_order = NewOrderSingle::market("AAPL", Side::Buy, 100.0)
+        .with_cl_ord_id("order-001")
+        .with_time_in_force(TimeInForce::Day);
+
+    println!("  Symbol: {}", buy_order.symbol);
+    println!("  Side: {:?}", buy_order.side);
+    println!("  Order Type: {:?}", buy_order.ord_type);
+    println!("  Quantity: {}", buy_order.order_qty);
+    println!("  Time in Force: {:?}", buy_order.time_in_force);
+    println!("  Client Order ID: {}", buy_order.cl_ord_id);
+
+    // Create market sell order
+    println!("\n--- Create Market Sell Order ---");
+    let sell_order = NewOrderSingle::market("MSFT", Side::Sell, 50.0)
+        .with_cl_ord_id("order-002")
+        .with_time_in_force(TimeInForce::Day);
+
+    println!("  Symbol: {}", sell_order.symbol);
+    println!("  Side: {:?}", sell_order.side);
+    println!("  Quantity: {}", sell_order.order_qty);
+
+    // Send order
+    println!("\n--- Send Order ---");
+    println!("  // Ensure session is active");
+    println!("  assert_eq!(client.state().await, SessionState::Active);");
+    println!();
+    println!("  // Send the order");
+    println!("  let cl_ord_id = client.send_order(&buy_order).await?;");
+    println!("  println!(\"Order sent: {{}}\", cl_ord_id);");
+
+    // New Order Single FIX fields
+    println!("\n--- New Order Single FIX Fields ---");
+    println!("  MsgType (35): D (New Order Single)");
+    println!("  ClOrdID (11): Client order ID");
+    println!("  Symbol (55): Stock symbol");
+    println!("  Side (54): 1=Buy, 2=Sell");
+    println!("  OrdType (40): 1=Market");
+    println!("  OrderQty (38): Order quantity");
+    println!("  TimeInForce (59): 0=Day, 1=GTC, 3=IOC, 4=FOK");
+    println!("  TransactTime (60): Transaction timestamp");
+
+    // Time in Force options
+    println!("\n--- Time in Force Options ---");
+    println!("  Day: Valid for trading day only");
+    println!("  GTC: Good Till Canceled");
+    println!("  IOC: Immediate Or Cancel");
+    println!("  FOK: Fill Or Kill");
+    println!("  OPG: At the Opening");
+    println!("  CLS: At the Close");
+
+    // Market order characteristics
+    println!("\n--- Market Order Characteristics ---");
+    println!("  - Executes immediately at best available price");
+    println!("  - No price guarantee");
+    println!("  - High fill probability");
+    println!("  - May experience slippage in volatile markets");
+    println!("  - Best for liquid securities");
+
+    // Wait for execution report
+    println!("\n--- Wait for Execution Report ---");
+    println!("  loop {{");
+    println!("      let msg = client.next_message().await?;");
+    println!("      if let Some(msg_type) = msg.msg_type() {{");
+    println!("          if msg_type == \"8\" {{ // ExecutionReport");
+    println!("              let report = client.parse_execution_report(&msg)?;");
+    println!("              println!(\"Status: {{:?}}\", report.ord_status);");
+    println!("              if report.ord_status == OrdStatus::Filled {{");
+    println!("                  println!(\"Filled at: {{}}\", report.avg_px);");
+    println!("                  break;");
+    println!("              }}");
+    println!("          }}");
+    println!("      }}");
+    println!("  }}");
+
+    // Best practices
+    println!("\n--- Best Practices ---");
+    println!("1. Use unique client order IDs");
+    println!("2. Track order state via execution reports");
+    println!("3. Handle partial fills");
+    println!("4. Implement timeout for order confirmation");
+    println!("5. Log all order activity");
+
+    println!("\n=== Example Complete ===");
+}

--- a/alpaca-fix/examples/fix_message_loop.rs
+++ b/alpaca-fix/examples/fix_message_loop.rs
@@ -1,0 +1,148 @@
+//! # FIX Message Loop
+//!
+//! This example demonstrates how to receive and process FIX messages
+//! in a continuous loop using the Alpaca FIX client.
+//!
+//! ## Prerequisites
+//!
+//! Set environment variables:
+//! - `ALPACA_API_KEY`: Your Alpaca API key
+//! - `ALPACA_API_SECRET`: Your Alpaca secret key
+//!
+//! ## Usage
+//!
+//! ```bash
+//! cargo run -p alpaca-fix --example fix_message_loop
+//! ```
+//!
+//! **Note**: This example demonstrates the API structure. FIX connections
+//! require special credentials and server access.
+
+fn main() {
+    println!("=== FIX Message Loop ===\n");
+
+    // Message loop overview
+    println!("--- Message Loop Overview ---");
+    println!("  The message loop continuously receives and processes");
+    println!("  incoming FIX messages from the server.");
+
+    // Basic message loop
+    println!("\n--- Basic Message Loop ---");
+    println!("  loop {{");
+    println!("      match client.next_message().await {{");
+    println!("          Ok(msg) => {{");
+    println!("              // Process the message");
+    println!("              client.process_message(&msg).await?;");
+    println!("          }}");
+    println!("          Err(e) => {{");
+    println!("              eprintln!(\"Error receiving message: {{}}\", e);");
+    println!("              break;");
+    println!("          }}");
+    println!("      }}");
+    println!("  }}");
+
+    // Message type dispatch
+    println!("\n--- Message Type Dispatch ---");
+    println!("  loop {{");
+    println!("      let msg = client.next_message().await?;");
+    println!("      ");
+    println!("      if let Some(msg_type) = msg.msg_type() {{");
+    println!("          match msg_type {{");
+    println!("              \"0\" => println!(\"Heartbeat\"),");
+    println!("              \"1\" => println!(\"TestRequest\"),");
+    println!("              \"5\" => {{");
+    println!("                  println!(\"Logout received\");");
+    println!("                  break;");
+    println!("              }}");
+    println!("              \"8\" => {{");
+    println!("                  let report = client.parse_execution_report(&msg)?;");
+    println!("                  handle_execution_report(report);");
+    println!("              }}");
+    println!("              \"9\" => println!(\"OrderCancelReject\"),");
+    println!("              _ => println!(\"Unknown: {{}}\", msg_type),");
+    println!("          }}");
+    println!("      }}");
+    println!("  }}");
+
+    // Common message types
+    println!("\n--- Common Message Types ---");
+    println!("  0: Heartbeat");
+    println!("  1: TestRequest");
+    println!("  2: ResendRequest");
+    println!("  3: Reject");
+    println!("  4: SequenceReset");
+    println!("  5: Logout");
+    println!("  8: ExecutionReport");
+    println!("  9: OrderCancelReject");
+    println!("  A: Logon");
+    println!("  D: NewOrderSingle");
+    println!("  F: OrderCancelRequest");
+    println!("  G: OrderCancelReplaceRequest");
+
+    // Async message handling
+    println!("\n--- Async Message Handling ---");
+    println!("  // Use tokio::select! for multiple async operations");
+    println!("  loop {{");
+    println!("      tokio::select! {{");
+    println!("          msg = client.next_message() => {{");
+    println!("              match msg {{");
+    println!("                  Ok(m) => process_message(m).await,");
+    println!("                  Err(_) => break,");
+    println!("              }}");
+    println!("          }}");
+    println!("          _ = shutdown_signal.recv() => {{");
+    println!("              println!(\"Shutdown requested\");");
+    println!("              break;");
+    println!("          }}");
+    println!("      }}");
+    println!("  }}");
+
+    // Error handling in loop
+    println!("\n--- Error Handling ---");
+    println!("  let mut consecutive_errors = 0;");
+    println!("  loop {{");
+    println!("      match client.next_message().await {{");
+    println!("          Ok(msg) => {{");
+    println!("              consecutive_errors = 0;");
+    println!("              // Process message...");
+    println!("          }}");
+    println!("          Err(e) => {{");
+    println!("              consecutive_errors += 1;");
+    println!("              if consecutive_errors > 5 {{");
+    println!("                  eprintln!(\"Too many errors, exiting\");");
+    println!("                  break;");
+    println!("              }}");
+    println!("          }}");
+    println!("      }}");
+    println!("  }}");
+
+    // Graceful shutdown
+    println!("\n--- Graceful Shutdown ---");
+    println!("  // Handle Ctrl+C");
+    println!("  let (shutdown_tx, mut shutdown_rx) = mpsc::channel(1);");
+    println!("  ");
+    println!("  tokio::spawn(async move {{");
+    println!("      tokio::signal::ctrl_c().await.unwrap();");
+    println!("      let _ = shutdown_tx.send(()).await;");
+    println!("  }});");
+    println!("  ");
+    println!("  // In message loop, check for shutdown");
+    println!("  // Then disconnect gracefully");
+    println!("  client.disconnect().await?;");
+
+    // Message processing patterns
+    println!("\n--- Message Processing Patterns ---");
+    println!("  1. Synchronous: Process each message before next");
+    println!("  2. Channel-based: Send to worker tasks");
+    println!("  3. Event-driven: Emit events for handlers");
+
+    // Best practices
+    println!("\n--- Best Practices ---");
+    println!("1. Always process session-level messages");
+    println!("2. Handle errors without crashing the loop");
+    println!("3. Implement graceful shutdown");
+    println!("4. Log all incoming messages");
+    println!("5. Monitor message processing latency");
+
+    println!("\n=== Example Complete ===");
+}


### PR DESCRIPTION
Add 8 examples for alpaca-fix Connection & Trading:

- fix_connect.rs: Connect to FIX server
- fix_disconnect.rs: Graceful disconnect
- fix_market_order.rs: Send market order via FIX
- fix_limit_order.rs: Send limit order via FIX
- fix_cancel_order.rs: Cancel order via FIX
- fix_execution_reports.rs: Process execution reports
- fix_heartbeat.rs: Heartbeat handling
- fix_message_loop.rs: Receive and process messages

Also:
- Update alpaca-fix README with Connection & Trading examples section

Closes #57