### PR TITLE
feat(examples): implement Integration Bots & Strategies examples (E012)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,18 @@ Run with `cargo run --example <name>`:
 | `advanced_retry_strategies` | Retry patterns with exponential backoff |
 | `advanced_rate_limiting` | Rate limiting strategies |
 
+### Bots & Strategies Examples
+
+| Example | Description |
+|---------|-------------|
+| `integration_paper_trading_bot` | Simple paper trading bot |
+| `integration_realtime_order_tracker` | Place order and track via WebSocket |
+| `integration_historical_data_download` | Download and save historical bars |
+| `integration_realtime_data_logger` | Log streaming data to file |
+| `integration_bracket_order_with_updates` | Place bracket order and monitor |
+| `integration_portfolio_rebalancer` | Rebalance portfolio to targets |
+| `integration_options_scanner` | Scan and filter options |
+
 ### Base Examples
 
 | Example | Description |

--- a/examples/integration_bracket_order_with_updates.rs
+++ b/examples/integration_bracket_order_with_updates.rs
@@ -1,0 +1,157 @@
+//! # Bracket Order with Updates
+//!
+//! This example demonstrates how to place a bracket order and monitor
+//! all legs via WebSocket updates.
+//!
+//! ## Prerequisites
+//!
+//! Set environment variables:
+//! - `ALPACA_API_KEY`: Your Alpaca API key
+//! - `ALPACA_API_SECRET`: Your Alpaca secret key
+//!
+//! ## Usage
+//!
+//! ```bash
+//! cargo run --example integration_bracket_order_with_updates
+//! ```
+
+use alpaca_base::{Credentials, Environment, OrderSide, TimeInForce};
+
+fn main() {
+    println!("=== Bracket Order with Updates ===\n");
+
+    // What is a bracket order?
+    println!("--- What is a Bracket Order? ---");
+    println!("  A bracket order consists of three linked orders:");
+    println!("  1. Entry order (market or limit)");
+    println!("  2. Take profit order (limit sell above entry)");
+    println!("  3. Stop loss order (stop sell below entry)");
+    println!();
+    println!("  When entry fills, both exit orders become active.");
+    println!("  When one exit fills, the other is canceled (OCO).");
+
+    // Initialize clients
+    println!("\n--- Initialize Clients ---");
+    println!("  let credentials = Credentials::from_env()?;");
+    println!("  let http_client = AlpacaHttpClient::new(credentials.clone(), Environment::Paper)?;");
+    println!("  let ws_client = AlpacaWebSocketClient::from_env(Environment::Paper)?;");
+    println!("  let mut stream = ws_client.subscribe_trade_updates().await?;");
+
+    // Create bracket order
+    println!("\n--- Create Bracket Order ---");
+    println!("  let bracket = CreateOrderRequest::market(\"AAPL\", 10.0, OrderSide::Buy)");
+    println!("      .time_in_force(TimeInForce::Day)");
+    println!("      .take_profit(TakeProfitParams {{");
+    println!("          limit_price: 160.00,  // Sell when price reaches $160");
+    println!("      }})");
+    println!("      .stop_loss(StopLossParams {{");
+    println!("          stop_price: 145.00,   // Sell when price drops to $145");
+    println!("          limit_price: None,    // Market order at stop");
+    println!("      }});");
+    println!("  ");
+    println!("  let order = http_client.create_order(&bracket).await?;");
+    println!("  println!(\"Bracket order placed: {{}}\", order.id);");
+
+    // Track order legs
+    println!("\n--- Track Order Legs ---");
+    println!("  struct BracketState {{");
+    println!("      entry_id: String,");
+    println!("      take_profit_id: Option<String>,");
+    println!("      stop_loss_id: Option<String>,");
+    println!("      entry_filled: bool,");
+    println!("      exit_filled: bool,");
+    println!("  }}");
+    println!("  ");
+    println!("  let mut state = BracketState {{");
+    println!("      entry_id: order.id.clone(),");
+    println!("      take_profit_id: order.legs.get(0).map(|l| l.id.clone()),");
+    println!("      stop_loss_id: order.legs.get(1).map(|l| l.id.clone()),");
+    println!("      entry_filled: false,");
+    println!("      exit_filled: false,");
+    println!("  }};");
+
+    // Monitor updates
+    println!("\n--- Monitor Updates ---");
+    println!("  while let Some(update) = stream.next().await {{");
+    println!("      if let Ok(WebSocketMessage::TradeUpdate(tu)) = update {{");
+    println!("          let order_id = &tu.order.id;");
+    println!("          ");
+    println!("          if order_id == &state.entry_id {{");
+    println!("              match tu.event {{");
+    println!("                  TradeUpdateEvent::Fill => {{");
+    println!("                      println!(\"Entry filled at ${{}}\", tu.order.filled_avg_price);");
+    println!("                      state.entry_filled = true;");
+    println!("                  }}");
+    println!("                  TradeUpdateEvent::Rejected => {{");
+    println!("                      println!(\"Entry rejected!\");");
+    println!("                      break;");
+    println!("                  }}");
+    println!("                  _ => {{}}");
+    println!("              }}");
+    println!("          }} else if Some(order_id) == state.take_profit_id.as_ref() {{");
+    println!("              if tu.event == TradeUpdateEvent::Fill {{");
+    println!("                  println!(\"Take profit hit! Sold at ${{}}\", tu.order.filled_avg_price);");
+    println!("                  state.exit_filled = true;");
+    println!("                  break;");
+    println!("              }}");
+    println!("          }} else if Some(order_id) == state.stop_loss_id.as_ref() {{");
+    println!("              if tu.event == TradeUpdateEvent::Fill {{");
+    println!("                  println!(\"Stop loss triggered! Sold at ${{}}\", tu.order.filled_avg_price);");
+    println!("                  state.exit_filled = true;");
+    println!("                  break;");
+    println!("              }}");
+    println!("          }}");
+    println!("      }}");
+    println!("  }}");
+
+    // Calculate P&L
+    println!("\n--- Calculate P&L ---");
+    println!("  fn calculate_pnl(entry_price: f64, exit_price: f64, qty: f64, side: OrderSide) -> f64 {{");
+    println!("      match side {{");
+    println!("          OrderSide::Buy => (exit_price - entry_price) * qty,");
+    println!("          OrderSide::Sell => (entry_price - exit_price) * qty,");
+    println!("      }}");
+    println!("  }}");
+    println!("  ");
+    println!("  let pnl = calculate_pnl(entry_price, exit_price, 10.0, OrderSide::Buy);");
+    println!("  println!(\"P&L: ${:.2}\", pnl);");
+
+    // Bracket order scenarios
+    println!("\n--- Bracket Order Scenarios ---");
+    println!("  Scenario 1: Price goes up");
+    println!("    Entry fills at $150");
+    println!("    Price rises to $160");
+    println!("    Take profit fills -> Stop loss canceled");
+    println!("    P&L: +$100 (10 shares × $10)");
+    println!();
+    println!("  Scenario 2: Price goes down");
+    println!("    Entry fills at $150");
+    println!("    Price drops to $145");
+    println!("    Stop loss fills -> Take profit canceled");
+    println!("    P&L: -$50 (10 shares × $5)");
+
+    // Modify bracket legs
+    println!("\n--- Modify Bracket Legs ---");
+    println!("  // Adjust take profit");
+    println!("  let replace = ReplaceOrderRequest {{");
+    println!("      limit_price: Some(165.00),  // New take profit");
+    println!("      ..Default::default()");
+    println!("  }};");
+    println!("  http_client.replace_order(&take_profit_id, &replace).await?;");
+
+    // Best practices
+    println!("\n--- Best Practices ---");
+    println!("1. Set realistic take profit and stop loss levels");
+    println!("2. Consider volatility when setting stop distance");
+    println!("3. Monitor all three legs for updates");
+    println!("4. Handle partial fills appropriately");
+    println!("5. Log all bracket order events");
+
+    // Display example values
+    let _credentials = Credentials::paper("demo_key", "demo_secret");
+    let _environment = Environment::Paper;
+    let _side = OrderSide::Buy;
+    let _tif = TimeInForce::Day;
+
+    println!("\n=== Example Complete ===");
+}

--- a/examples/integration_historical_data_download.rs
+++ b/examples/integration_historical_data_download.rs
@@ -1,0 +1,161 @@
+//! # Historical Data Download
+//!
+//! This example demonstrates how to download and save historical bars
+//! for analysis or backtesting.
+//!
+//! ## Prerequisites
+//!
+//! Set environment variables:
+//! - `ALPACA_API_KEY`: Your Alpaca API key
+//! - `ALPACA_API_SECRET`: Your Alpaca secret key
+//!
+//! ## Usage
+//!
+//! ```bash
+//! cargo run --example integration_historical_data_download
+//! ```
+
+use alpaca_base::{Credentials, Environment, Timeframe};
+
+fn main() {
+    println!("=== Historical Data Download ===\n");
+
+    // Configuration
+    println!("--- Configuration ---");
+    println!("  Symbols: AAPL, MSFT, GOOGL");
+    println!("  Timeframe: 1 Day");
+    println!("  Date Range: 2024-01-01 to 2024-12-31");
+    println!("  Output: CSV files");
+
+    // Initialize client
+    println!("\n--- Initialize Client ---");
+    println!("  let credentials = Credentials::from_env()?;");
+    println!("  let client = AlpacaHttpClient::new(credentials, Environment::Paper)?;");
+
+    // Download bars for single symbol
+    println!("\n--- Download Single Symbol ---");
+    println!("  let params = BarsParams::new()");
+    println!("      .symbol(\"AAPL\")");
+    println!("      .timeframe(Timeframe::Day)");
+    println!("      .start(\"2024-01-01T00:00:00Z\")");
+    println!("      .end(\"2024-12-31T23:59:59Z\")");
+    println!("      .limit(10000);");
+    println!("  ");
+    println!("  let bars = client.get_bars(&params).await?;");
+    println!("  println!(\"Downloaded {{}} bars for AAPL\", bars.len());");
+
+    // Download bars for multiple symbols
+    println!("\n--- Download Multiple Symbols ---");
+    println!("  let symbols = vec![\"AAPL\", \"MSFT\", \"GOOGL\"];");
+    println!("  let mut all_bars: HashMap<String, Vec<Bar>> = HashMap::new();");
+    println!("  ");
+    println!("  for symbol in symbols {{");
+    println!("      let params = BarsParams::new()");
+    println!("          .symbol(symbol)");
+    println!("          .timeframe(Timeframe::Day)");
+    println!("          .start(\"2024-01-01T00:00:00Z\")");
+    println!("          .end(\"2024-12-31T23:59:59Z\");");
+    println!("      ");
+    println!("      let bars = client.get_bars(&params).await?;");
+    println!("      println!(\"Downloaded {{}} bars for {{}}\", bars.len(), symbol);");
+    println!("      all_bars.insert(symbol.to_string(), bars);");
+    println!("  }}");
+
+    // Handle pagination
+    println!("\n--- Handle Pagination ---");
+    println!("  let mut all_bars = Vec::new();");
+    println!("  let mut page_token: Option<String> = None;");
+    println!("  ");
+    println!("  loop {{");
+    println!("      let mut params = BarsParams::new()");
+    println!("          .symbol(\"AAPL\")");
+    println!("          .timeframe(Timeframe::Minute)");
+    println!("          .limit(10000);");
+    println!("      ");
+    println!("      if let Some(token) = &page_token {{");
+    println!("          params = params.page_token(token);");
+    println!("      }}");
+    println!("      ");
+    println!("      let response = client.get_bars_with_pagination(&params).await?;");
+    println!("      all_bars.extend(response.bars);");
+    println!("      ");
+    println!("      page_token = response.next_page_token;");
+    println!("      if page_token.is_none() {{");
+    println!("          break;");
+    println!("      }}");
+    println!("  }}");
+    println!("  println!(\"Total bars downloaded: {{}}\", all_bars.len());");
+
+    // Save to CSV
+    println!("\n--- Save to CSV ---");
+    println!("  fn save_bars_to_csv(bars: &[Bar], filename: &str) -> Result<()> {{");
+    println!("      let mut writer = csv::Writer::from_path(filename)?;");
+    println!("      ");
+    println!("      // Write header");
+    println!("      writer.write_record(&[");
+    println!("          \"timestamp\", \"open\", \"high\", \"low\", \"close\", \"volume\"");
+    println!("      ])?;");
+    println!("      ");
+    println!("      // Write data");
+    println!("      for bar in bars {{");
+    println!("          writer.write_record(&[");
+    println!("              bar.timestamp.to_rfc3339(),");
+    println!("              bar.open.to_string(),");
+    println!("              bar.high.to_string(),");
+    println!("              bar.low.to_string(),");
+    println!("              bar.close.to_string(),");
+    println!("              bar.volume.to_string(),");
+    println!("          ])?;");
+    println!("      }}");
+    println!("      ");
+    println!("      writer.flush()?;");
+    println!("      Ok(())");
+    println!("  }}");
+
+    // Available timeframes
+    println!("\n--- Available Timeframes ---");
+    let timeframes = [
+        (Timeframe::Minute, "1 minute bars"),
+        (Timeframe::Hour, "1 hour bars"),
+        (Timeframe::Day, "1 day bars"),
+        (Timeframe::Week, "1 week bars"),
+        (Timeframe::Month, "1 month bars"),
+    ];
+
+    for (tf, desc) in timeframes {
+        println!("  {:?}: {}", tf, desc);
+    }
+
+    // Data quality checks
+    println!("\n--- Data Quality Checks ---");
+    println!("  fn validate_bars(bars: &[Bar]) -> bool {{");
+    println!("      for bar in bars {{");
+    println!("          // Check OHLC validity");
+    println!("          if bar.high < bar.low {{");
+    println!("              return false;");
+    println!("          }}");
+    println!("          if bar.open > bar.high || bar.open < bar.low {{");
+    println!("              return false;");
+    println!("          }}");
+    println!("          if bar.close > bar.high || bar.close < bar.low {{");
+    println!("              return false;");
+    println!("          }}");
+    println!("      }}");
+    println!("      true");
+    println!("  }}");
+
+    // Best practices
+    println!("\n--- Best Practices ---");
+    println!("1. Use pagination for large date ranges");
+    println!("2. Respect rate limits (add delays between requests)");
+    println!("3. Validate downloaded data");
+    println!("4. Store data with timestamps in UTC");
+    println!("5. Handle market holidays (no data on closed days)");
+
+    // Display example values
+    let _credentials = Credentials::paper("demo_key", "demo_secret");
+    let _environment = Environment::Paper;
+    let _timeframe = Timeframe::Day;
+
+    println!("\n=== Example Complete ===");
+}

--- a/examples/integration_options_scanner.rs
+++ b/examples/integration_options_scanner.rs
@@ -1,0 +1,148 @@
+//! # Options Scanner
+//!
+//! This example demonstrates how to scan and filter options contracts
+//! using the Alpaca HTTP API.
+//!
+//! ## Prerequisites
+//!
+//! Set environment variables:
+//! - `ALPACA_API_KEY`: Your Alpaca API key
+//! - `ALPACA_API_SECRET`: Your Alpaca secret key
+//!
+//! ## Usage
+//!
+//! ```bash
+//! cargo run --example integration_options_scanner
+//! ```
+//!
+//! **Note**: Options trading requires approval from Alpaca.
+
+use alpaca_base::{Credentials, Environment};
+
+fn main() {
+    println!("=== Options Scanner ===\n");
+
+    // Options overview
+    println!("--- Options Overview ---");
+    println!("  Options give the right (not obligation) to buy/sell");
+    println!("  an underlying asset at a specific price by a date.");
+    println!();
+    println!("  Call: Right to BUY at strike price");
+    println!("  Put: Right to SELL at strike price");
+
+    // Initialize client
+    println!("\n--- Initialize Client ---");
+    println!("  let credentials = Credentials::from_env()?;");
+    println!("  let client = AlpacaHttpClient::new(credentials, Environment::Paper)?;");
+
+    // Get options chain
+    println!("\n--- Get Options Chain ---");
+    println!("  let params = OptionsChainParams::new(\"AAPL\")");
+    println!("      .expiration_date_gte(\"2024-03-01\")");
+    println!("      .expiration_date_lte(\"2024-06-30\")");
+    println!("      .strike_price_gte(140.0)");
+    println!("      .strike_price_lte(180.0);");
+    println!("  ");
+    println!("  let chain = client.get_options_chain(&params).await?;");
+    println!("  println!(\"Found {{}} contracts\", chain.len());");
+
+    // Filter by type
+    println!("\n--- Filter by Option Type ---");
+    println!("  // Get only calls");
+    println!("  let calls: Vec<_> = chain.iter()");
+    println!("      .filter(|c| c.option_type == OptionType::Call)");
+    println!("      .collect();");
+    println!("  ");
+    println!("  // Get only puts");
+    println!("  let puts: Vec<_> = chain.iter()");
+    println!("      .filter(|c| c.option_type == OptionType::Put)");
+    println!("      .collect();");
+
+    // Options contract fields
+    println!("\n--- Options Contract Fields ---");
+    println!("  symbol: Option symbol (e.g., AAPL240315C00150000)");
+    println!("  underlying_symbol: Underlying stock (e.g., AAPL)");
+    println!("  option_type: Call or Put");
+    println!("  strike_price: Strike price");
+    println!("  expiration_date: Expiration date");
+    println!("  open_interest: Number of open contracts");
+    println!("  implied_volatility: IV percentage");
+
+    // Scanner criteria
+    println!("\n--- Scanner Criteria ---");
+    println!("  struct ScanCriteria {{");
+    println!("      min_open_interest: u32,");
+    println!("      max_days_to_expiry: u32,");
+    println!("      min_implied_volatility: f64,");
+    println!("      max_implied_volatility: f64,");
+    println!("      moneyness: Moneyness,  // ITM, ATM, OTM");
+    println!("  }}");
+    println!("  ");
+    println!("  enum Moneyness {{");
+    println!("      InTheMoney,   // Call: strike < price, Put: strike > price");
+    println!("      AtTheMoney,   // strike ≈ price");
+    println!("      OutOfMoney,   // Call: strike > price, Put: strike < price");
+    println!("  }}");
+
+    // Scan for high IV options
+    println!("\n--- Scan: High IV Options ---");
+    println!("  let high_iv = chain.iter()");
+    println!("      .filter(|c| c.implied_volatility > 0.50)  // IV > 50%");
+    println!("      .filter(|c| c.open_interest > 100)");
+    println!("      .collect::<Vec<_>>();");
+    println!("  ");
+    println!("  println!(\"High IV options:\");");
+    println!("  for opt in high_iv {{");
+    println!("      println!(\"  {{}} IV: {{:.1}}%\", opt.symbol, opt.implied_volatility * 100.0);");
+    println!("  }}");
+
+    // Scan for liquid options
+    println!("\n--- Scan: Liquid Options ---");
+    println!("  let liquid = chain.iter()");
+    println!("      .filter(|c| c.open_interest > 1000)");
+    println!("      .filter(|c| c.volume > 100)");
+    println!("      .collect::<Vec<_>>();");
+
+    // Scan for near-expiry options
+    println!("\n--- Scan: Near Expiry (< 30 days) ---");
+    println!("  let today = Utc::now().date_naive();");
+    println!("  let near_expiry = chain.iter()");
+    println!("      .filter(|c| {{");
+    println!("          let expiry = NaiveDate::parse_from_str(&c.expiration_date, \"%Y-%m-%d\").unwrap();");
+    println!("          (expiry - today).num_days() < 30");
+    println!("      }})");
+    println!("      .collect::<Vec<_>>();");
+
+    // Greeks (if available)
+    println!("\n--- Options Greeks ---");
+    println!("  Delta: Price change per $1 move in underlying");
+    println!("  Gamma: Rate of change of delta");
+    println!("  Theta: Time decay per day");
+    println!("  Vega: Price change per 1% IV change");
+    println!("  Rho: Price change per 1% interest rate change");
+
+    // Strategy scanner
+    println!("\n--- Strategy: Covered Call Scanner ---");
+    println!("  // Find OTM calls for covered call strategy");
+    println!("  let underlying_price = 150.0;");
+    println!("  let covered_call_candidates = chain.iter()");
+    println!("      .filter(|c| c.option_type == OptionType::Call)");
+    println!("      .filter(|c| c.strike_price > underlying_price * 1.05)  // 5% OTM");
+    println!("      .filter(|c| days_to_expiry(c) >= 30 && days_to_expiry(c) <= 45)");
+    println!("      .filter(|c| c.open_interest > 100)");
+    println!("      .collect::<Vec<_>>();");
+
+    // Best practices
+    println!("\n--- Best Practices ---");
+    println!("1. Filter by open interest for liquidity");
+    println!("2. Check bid-ask spread before trading");
+    println!("3. Consider time decay (theta) for short positions");
+    println!("4. Monitor implied volatility changes");
+    println!("5. Understand assignment risk for ITM options");
+
+    // Display example values
+    let _credentials = Credentials::paper("demo_key", "demo_secret");
+    let _environment = Environment::Paper;
+
+    println!("\n=== Example Complete ===");
+}

--- a/examples/integration_paper_trading_bot.rs
+++ b/examples/integration_paper_trading_bot.rs
@@ -1,0 +1,160 @@
+//! # Paper Trading Bot
+//!
+//! This example demonstrates a simple paper trading bot that monitors
+//! market conditions and places orders based on simple rules.
+//!
+//! ## Prerequisites
+//!
+//! Set environment variables:
+//! - `ALPACA_API_KEY`: Your Alpaca API key
+//! - `ALPACA_API_SECRET`: Your Alpaca secret key
+//!
+//! ## Usage
+//!
+//! ```bash
+//! cargo run --example integration_paper_trading_bot
+//! ```
+//!
+//! **Note**: This example demonstrates the bot structure. Always test
+//! thoroughly with paper trading before any live trading.
+
+use alpaca_base::{Credentials, Environment, OrderSide, TimeInForce};
+
+fn main() {
+    println!("=== Paper Trading Bot ===\n");
+
+    // Bot configuration
+    println!("--- Bot Configuration ---");
+    println!("  Symbol: AAPL");
+    println!("  Environment: Paper");
+    println!("  Strategy: Simple Moving Average Crossover");
+    println!("  Position Size: 10 shares");
+    println!("  Max Positions: 1");
+
+    // Initialize client
+    println!("\n--- Initialize Client ---");
+    println!("  let credentials = Credentials::from_env()?;");
+    println!("  let client = AlpacaHttpClient::new(credentials, Environment::Paper)?;");
+
+    // Check account status
+    println!("\n--- Check Account Status ---");
+    println!("  let account = client.get_account().await?;");
+    println!("  println!(\"Buying Power: ${{}}\", account.buying_power);");
+    println!("  println!(\"Portfolio Value: ${{}}\", account.portfolio_value);");
+    println!("  if account.trading_blocked {{");
+    println!("      panic!(\"Trading is blocked!\");");
+    println!("  }}");
+
+    // Bot state
+    println!("\n--- Bot State ---");
+    println!("  struct BotState {{");
+    println!("      position: Option<Position>,");
+    println!("      last_signal: Option<Signal>,");
+    println!("      trades_today: u32,");
+    println!("  }}");
+
+    // Trading signals
+    println!("\n--- Trading Signals ---");
+    println!("  enum Signal {{");
+    println!("      Buy,");
+    println!("      Sell,");
+    println!("      Hold,");
+    println!("  }}");
+
+    // Strategy implementation
+    println!("\n--- Strategy: SMA Crossover ---");
+    println!("  fn calculate_signal(bars: &[Bar]) -> Signal {{");
+    println!("      let short_sma = calculate_sma(&bars, 10);");
+    println!("      let long_sma = calculate_sma(&bars, 20);");
+    println!("      ");
+    println!("      if short_sma > long_sma {{");
+    println!("          Signal::Buy");
+    println!("      }} else if short_sma < long_sma {{");
+    println!("          Signal::Sell");
+    println!("      }} else {{");
+    println!("          Signal::Hold");
+    println!("      }}");
+    println!("  }}");
+
+    // Main trading loop
+    println!("\n--- Main Trading Loop ---");
+    println!("  loop {{");
+    println!("      // Check if market is open");
+    println!("      let clock = client.get_clock().await?;");
+    println!("      if !clock.is_open {{");
+    println!("          println!(\"Market closed, waiting...\");");
+    println!("          tokio::time::sleep(Duration::from_secs(60)).await;");
+    println!("          continue;");
+    println!("      }}");
+    println!("      ");
+    println!("      // Get historical data");
+    println!("      let bars = client.get_bars(&params).await?;");
+    println!("      ");
+    println!("      // Calculate signal");
+    println!("      let signal = calculate_signal(&bars);");
+    println!("      ");
+    println!("      // Execute based on signal");
+    println!("      match signal {{");
+    println!("          Signal::Buy => execute_buy(&client).await?,");
+    println!("          Signal::Sell => execute_sell(&client).await?,");
+    println!("          Signal::Hold => {{}},");
+    println!("      }}");
+    println!("      ");
+    println!("      // Wait before next iteration");
+    println!("      tokio::time::sleep(Duration::from_secs(60)).await;");
+    println!("  }}");
+
+    // Execute buy
+    println!("\n--- Execute Buy ---");
+    println!("  async fn execute_buy(client: &AlpacaHttpClient) -> Result<()> {{");
+    println!("      // Check if we already have a position");
+    println!("      let positions = client.get_positions().await?;");
+    println!("      if positions.iter().any(|p| p.symbol == \"AAPL\") {{");
+    println!("          return Ok(()); // Already have position");
+    println!("      }}");
+    println!("      ");
+    println!("      let order = CreateOrderRequest::market(\"AAPL\", 10.0, OrderSide::Buy)");
+    println!("          .time_in_force(TimeInForce::Day);");
+    println!("      let result = client.create_order(&order).await?;");
+    println!("      println!(\"Buy order placed: {{}}\", result.id);");
+    println!("      Ok(())");
+    println!("  }}");
+
+    // Execute sell
+    println!("\n--- Execute Sell ---");
+    println!("  async fn execute_sell(client: &AlpacaHttpClient) -> Result<()> {{");
+    println!("      // Check if we have a position to sell");
+    println!("      let positions = client.get_positions().await?;");
+    println!("      if let Some(pos) = positions.iter().find(|p| p.symbol == \"AAPL\") {{");
+    println!("          let qty = pos.qty.parse::<f64>().unwrap_or(0.0);");
+    println!("          let order = CreateOrderRequest::market(\"AAPL\", qty, OrderSide::Sell)");
+    println!("              .time_in_force(TimeInForce::Day);");
+    println!("          let result = client.create_order(&order).await?;");
+    println!("          println!(\"Sell order placed: {{}}\", result.id);");
+    println!("      }}");
+    println!("      Ok(())");
+    println!("  }}");
+
+    // Risk management
+    println!("\n--- Risk Management ---");
+    println!("1. Position sizing: Fixed 10 shares");
+    println!("2. Max positions: 1 at a time");
+    println!("3. Stop loss: Not implemented (add for production)");
+    println!("4. Daily loss limit: Not implemented (add for production)");
+
+    // Best practices
+    println!("\n--- Best Practices ---");
+    println!("1. Always test with paper trading first");
+    println!("2. Implement proper error handling");
+    println!("3. Add logging for all trades");
+    println!("4. Monitor bot performance regularly");
+    println!("5. Implement circuit breakers for losses");
+
+    // Display example values
+    let _credentials = Credentials::paper("demo_key", "demo_secret");
+    let _environment = Environment::Paper;
+    let _side = OrderSide::Buy;
+    let _tif = TimeInForce::Day;
+
+    println!("\n=== Example Complete ===");
+}

--- a/examples/integration_portfolio_rebalancer.rs
+++ b/examples/integration_portfolio_rebalancer.rs
@@ -1,0 +1,164 @@
+//! # Portfolio Rebalancer
+//!
+//! This example demonstrates how to rebalance a portfolio to target
+//! allocations using the Alpaca HTTP API.
+//!
+//! ## Prerequisites
+//!
+//! Set environment variables:
+//! - `ALPACA_API_KEY`: Your Alpaca API key
+//! - `ALPACA_API_SECRET`: Your Alpaca secret key
+//!
+//! ## Usage
+//!
+//! ```bash
+//! cargo run --example integration_portfolio_rebalancer
+//! ```
+
+use alpaca_base::{Credentials, Environment, OrderSide, TimeInForce};
+
+fn main() {
+    println!("=== Portfolio Rebalancer ===\n");
+
+    // Target allocation
+    println!("--- Target Allocation ---");
+    println!("  AAPL: 30%");
+    println!("  MSFT: 25%");
+    println!("  GOOGL: 20%");
+    println!("  SPY: 15%");
+    println!("  Cash: 10%");
+
+    // Initialize client
+    println!("\n--- Initialize Client ---");
+    println!("  let credentials = Credentials::from_env()?;");
+    println!("  let client = AlpacaHttpClient::new(credentials, Environment::Paper)?;");
+
+    // Get current portfolio
+    println!("\n--- Get Current Portfolio ---");
+    println!("  let account = client.get_account().await?;");
+    println!("  let portfolio_value = account.portfolio_value.parse::<f64>()?;");
+    println!("  println!(\"Portfolio Value: ${:.2}\", portfolio_value);");
+    println!("  ");
+    println!("  let positions = client.get_positions().await?;");
+    println!("  for pos in &positions {{");
+    println!("      let value = pos.market_value.parse::<f64>()?;");
+    println!("      let pct = value / portfolio_value * 100.0;");
+    println!("      println!(\"  {{}}: ${:.2} ({:.1}%)\", pos.symbol, value, pct);");
+    println!("  }}");
+
+    // Calculate current vs target
+    println!("\n--- Calculate Rebalance ---");
+    println!("  struct Allocation {{");
+    println!("      symbol: String,");
+    println!("      target_pct: f64,");
+    println!("      current_pct: f64,");
+    println!("      current_value: f64,");
+    println!("      target_value: f64,");
+    println!("      diff_value: f64,");
+    println!("  }}");
+    println!("  ");
+    println!("  fn calculate_rebalance(");
+    println!("      positions: &[Position],");
+    println!("      targets: &HashMap<String, f64>,");
+    println!("      portfolio_value: f64,");
+    println!("  ) -> Vec<Allocation> {{");
+    println!("      targets.iter().map(|(symbol, target_pct)| {{");
+    println!("          let current = positions.iter()");
+    println!("              .find(|p| &p.symbol == symbol)");
+    println!("              .map(|p| p.market_value.parse::<f64>().unwrap_or(0.0))");
+    println!("              .unwrap_or(0.0);");
+    println!("          ");
+    println!("          let target_value = portfolio_value * target_pct / 100.0;");
+    println!("          Allocation {{");
+    println!("              symbol: symbol.clone(),");
+    println!("              target_pct: *target_pct,");
+    println!("              current_pct: current / portfolio_value * 100.0,");
+    println!("              current_value: current,");
+    println!("              target_value,");
+    println!("              diff_value: target_value - current,");
+    println!("          }}");
+    println!("      }}).collect()");
+    println!("  }}");
+
+    // Generate orders
+    println!("\n--- Generate Rebalance Orders ---");
+    println!("  fn generate_orders(");
+    println!("      allocations: &[Allocation],");
+    println!("      prices: &HashMap<String, f64>,");
+    println!("      min_trade_value: f64,");
+    println!("  ) -> Vec<CreateOrderRequest> {{");
+    println!("      allocations.iter()");
+    println!("          .filter(|a| a.diff_value.abs() > min_trade_value)");
+    println!("          .map(|a| {{");
+    println!("              let price = prices.get(&a.symbol).unwrap_or(&0.0);");
+    println!("              let qty = (a.diff_value.abs() / price).floor();");
+    println!("              let side = if a.diff_value > 0.0 {{");
+    println!("                  OrderSide::Buy");
+    println!("              }} else {{");
+    println!("                  OrderSide::Sell");
+    println!("              }};");
+    println!("              CreateOrderRequest::market(&a.symbol, qty, side)");
+    println!("                  .time_in_force(TimeInForce::Day)");
+    println!("          }})");
+    println!("          .collect()");
+    println!("  }}");
+
+    // Execute rebalance
+    println!("\n--- Execute Rebalance ---");
+    println!("  // Sell orders first to free up cash");
+    println!("  let sell_orders: Vec<_> = orders.iter()");
+    println!("      .filter(|o| o.side == OrderSide::Sell)");
+    println!("      .collect();");
+    println!("  ");
+    println!("  for order in sell_orders {{");
+    println!("      let result = client.create_order(order).await?;");
+    println!("      println!(\"Sell order: {{}} {{}}\", result.symbol, result.qty);");
+    println!("  }}");
+    println!("  ");
+    println!("  // Wait for sells to settle");
+    println!("  tokio::time::sleep(Duration::from_secs(2)).await;");
+    println!("  ");
+    println!("  // Then buy orders");
+    println!("  let buy_orders: Vec<_> = orders.iter()");
+    println!("      .filter(|o| o.side == OrderSide::Buy)");
+    println!("      .collect();");
+    println!("  ");
+    println!("  for order in buy_orders {{");
+    println!("      let result = client.create_order(order).await?;");
+    println!("      println!(\"Buy order: {{}} {{}}\", result.symbol, result.qty);");
+    println!("  }}");
+
+    // Rebalance thresholds
+    println!("\n--- Rebalance Thresholds ---");
+    println!("  const MIN_TRADE_VALUE: f64 = 100.0;  // Minimum $100 trade");
+    println!("  const DRIFT_THRESHOLD: f64 = 5.0;    // Rebalance if >5% drift");
+    println!("  ");
+    println!("  fn needs_rebalance(allocations: &[Allocation]) -> bool {{");
+    println!("      allocations.iter().any(|a| {{");
+    println!("          (a.current_pct - a.target_pct).abs() > DRIFT_THRESHOLD");
+    println!("      }})");
+    println!("  }}");
+
+    // Tax-efficient rebalancing
+    println!("\n--- Tax-Efficient Rebalancing ---");
+    println!("  1. Use new contributions to buy underweight assets");
+    println!("  2. Reinvest dividends into underweight assets");
+    println!("  3. Sell overweight assets with losses first (tax-loss harvesting)");
+    println!("  4. Consider holding period for long-term gains");
+
+    // Best practices
+    println!("\n--- Best Practices ---");
+    println!("1. Set minimum trade size to avoid small orders");
+    println!("2. Execute sells before buys");
+    println!("3. Use limit orders for better execution");
+    println!("4. Consider transaction costs");
+    println!("5. Rebalance periodically (quarterly/annually)");
+
+    // Display example values
+    let _credentials = Credentials::paper("demo_key", "demo_secret");
+    let _environment = Environment::Paper;
+    let _side = OrderSide::Buy;
+    let _tif = TimeInForce::Day;
+
+    println!("\n=== Example Complete ===");
+}

--- a/examples/integration_realtime_data_logger.rs
+++ b/examples/integration_realtime_data_logger.rs
@@ -1,0 +1,159 @@
+//! # Realtime Data Logger
+//!
+//! This example demonstrates how to log streaming market data to a file
+//! for later analysis.
+//!
+//! ## Prerequisites
+//!
+//! Set environment variables:
+//! - `ALPACA_API_KEY`: Your Alpaca API key
+//! - `ALPACA_API_SECRET`: Your Alpaca secret key
+//!
+//! ## Usage
+//!
+//! ```bash
+//! cargo run --example integration_realtime_data_logger
+//! ```
+
+use alpaca_base::{Credentials, Environment};
+
+fn main() {
+    println!("=== Realtime Data Logger ===\n");
+
+    // Configuration
+    println!("--- Configuration ---");
+    println!("  Symbols: AAPL, MSFT, SPY");
+    println!("  Data Types: Trades, Quotes, Bars");
+    println!("  Output: data_log.jsonl");
+    println!("  Format: JSON Lines (one JSON object per line)");
+
+    // Initialize WebSocket client
+    println!("\n--- Initialize WebSocket Client ---");
+    println!("  let credentials = Credentials::from_env()?;");
+    println!("  let client = AlpacaWebSocketClient::from_env(Environment::Paper)?;");
+
+    // Create log file
+    println!("\n--- Create Log File ---");
+    println!("  let file = OpenOptions::new()");
+    println!("      .create(true)");
+    println!("      .append(true)");
+    println!("      .open(\"data_log.jsonl\")?;");
+    println!("  let mut writer = BufWriter::new(file);");
+
+    // Subscribe to market data
+    println!("\n--- Subscribe to Market Data ---");
+    println!("  let symbols = vec![\"AAPL\", \"MSFT\", \"SPY\"];");
+    println!("  let mut stream = client.subscribe_market_data(");
+    println!("      &symbols,");
+    println!("      true,  // trades");
+    println!("      true,  // quotes");
+    println!("      true,  // bars");
+    println!("  ).await?;");
+
+    // Log entry structure
+    println!("\n--- Log Entry Structure ---");
+    println!("  #[derive(Serialize)]");
+    println!("  struct LogEntry {{");
+    println!("      timestamp: DateTime<Utc>,");
+    println!("      data_type: String,");
+    println!("      symbol: String,");
+    println!("      data: serde_json::Value,");
+    println!("  }}");
+
+    // Main logging loop
+    println!("\n--- Main Logging Loop ---");
+    println!("  while let Some(msg) = stream.next().await {{");
+    println!("      match msg {{");
+    println!("          Ok(WebSocketMessage::Trade(trade)) => {{");
+    println!("              let entry = LogEntry {{");
+    println!("                  timestamp: Utc::now(),");
+    println!("                  data_type: \"trade\".to_string(),");
+    println!("                  symbol: trade.symbol.clone(),");
+    println!("                  data: serde_json::to_value(&trade)?,");
+    println!("              }};");
+    println!("              writeln!(writer, \"{{}}\", serde_json::to_string(&entry)?)?;");
+    println!("          }}");
+    println!("          Ok(WebSocketMessage::Quote(quote)) => {{");
+    println!("              let entry = LogEntry {{");
+    println!("                  timestamp: Utc::now(),");
+    println!("                  data_type: \"quote\".to_string(),");
+    println!("                  symbol: quote.symbol.clone(),");
+    println!("                  data: serde_json::to_value(&quote)?,");
+    println!("              }};");
+    println!("              writeln!(writer, \"{{}}\", serde_json::to_string(&entry)?)?;");
+    println!("          }}");
+    println!("          Ok(WebSocketMessage::Bar(bar)) => {{");
+    println!("              let entry = LogEntry {{");
+    println!("                  timestamp: Utc::now(),");
+    println!("                  data_type: \"bar\".to_string(),");
+    println!("                  symbol: bar.symbol.clone(),");
+    println!("                  data: serde_json::to_value(&bar)?,");
+    println!("              }};");
+    println!("              writeln!(writer, \"{{}}\", serde_json::to_string(&entry)?)?;");
+    println!("          }}");
+    println!("          Err(e) => eprintln!(\"Error: {{}}\", e),");
+    println!("          _ => {{}}");
+    println!("      }}");
+    println!("      ");
+    println!("      // Flush periodically");
+    println!("      writer.flush()?;");
+    println!("  }}");
+
+    // File rotation
+    println!("\n--- File Rotation ---");
+    println!("  fn rotate_log_file(base_name: &str) -> Result<File> {{");
+    println!("      let timestamp = Utc::now().format(\"%Y%m%d_%H%M%S\");");
+    println!("      let filename = format!(\"{{}}_{{}}.jsonl\", base_name, timestamp);");
+    println!("      OpenOptions::new()");
+    println!("          .create(true)");
+    println!("          .write(true)");
+    println!("          .open(filename)");
+    println!("  }}");
+    println!("  ");
+    println!("  // Rotate every hour or when file exceeds size");
+    println!("  if log_size > MAX_FILE_SIZE || should_rotate_hourly() {{");
+    println!("      writer.flush()?;");
+    println!("      file = rotate_log_file(\"data_log\")?;");
+    println!("      writer = BufWriter::new(file);");
+    println!("  }}");
+
+    // Statistics tracking
+    println!("\n--- Statistics Tracking ---");
+    println!("  struct Stats {{");
+    println!("      trades_logged: u64,");
+    println!("      quotes_logged: u64,");
+    println!("      bars_logged: u64,");
+    println!("      bytes_written: u64,");
+    println!("      start_time: Instant,");
+    println!("  }}");
+    println!("  ");
+    println!("  // Print stats periodically");
+    println!("  println!(\"Logged: {{}} trades, {{}} quotes, {{}} bars\",");
+    println!("      stats.trades_logged, stats.quotes_logged, stats.bars_logged);");
+    println!("  println!(\"Rate: {{:.2}} msgs/sec\", messages_per_second);");
+
+    // Graceful shutdown
+    println!("\n--- Graceful Shutdown ---");
+    println!("  // Handle Ctrl+C");
+    println!("  tokio::select! {{");
+    println!("      _ = log_data(&mut stream, &mut writer) => {{}}");
+    println!("      _ = tokio::signal::ctrl_c() => {{");
+    println!("          println!(\"Shutting down...\");");
+    println!("          writer.flush()?;");
+    println!("      }}");
+    println!("  }}");
+
+    // Best practices
+    println!("\n--- Best Practices ---");
+    println!("1. Use buffered writes for performance");
+    println!("2. Flush periodically to prevent data loss");
+    println!("3. Implement file rotation for long-running loggers");
+    println!("4. Use JSON Lines format for easy parsing");
+    println!("5. Include timestamps in log entries");
+
+    // Display example values
+    let _credentials = Credentials::paper("demo_key", "demo_secret");
+    let _environment = Environment::Paper;
+
+    println!("\n=== Example Complete ===");
+}

--- a/examples/integration_realtime_order_tracker.rs
+++ b/examples/integration_realtime_order_tracker.rs
@@ -1,0 +1,129 @@
+//! # Realtime Order Tracker
+//!
+//! This example demonstrates how to place an order and track its status
+//! in real-time using WebSocket updates.
+//!
+//! ## Prerequisites
+//!
+//! Set environment variables:
+//! - `ALPACA_API_KEY`: Your Alpaca API key
+//! - `ALPACA_API_SECRET`: Your Alpaca secret key
+//!
+//! ## Usage
+//!
+//! ```bash
+//! cargo run --example integration_realtime_order_tracker
+//! ```
+
+use alpaca_base::{Credentials, Environment, OrderSide, TimeInForce};
+
+fn main() {
+    println!("=== Realtime Order Tracker ===\n");
+
+    // Initialize clients
+    println!("--- Initialize Clients ---");
+    println!("  let credentials = Credentials::from_env()?;");
+    println!("  let http_client = AlpacaHttpClient::new(credentials.clone(), Environment::Paper)?;");
+    println!("  let ws_client = AlpacaWebSocketClient::from_env(Environment::Paper)?;");
+
+    // Connect to WebSocket for trade updates
+    println!("\n--- Connect to Trade Updates ---");
+    println!("  let mut stream = ws_client.subscribe_trade_updates().await?;");
+    println!("  println!(\"Connected to trade updates stream\");");
+
+    // Place order via HTTP
+    println!("\n--- Place Order via HTTP ---");
+    println!("  let order = CreateOrderRequest::limit(\"AAPL\", 10.0, OrderSide::Buy, 150.00)");
+    println!("      .time_in_force(TimeInForce::Day)");
+    println!("      .client_order_id(\"tracker-001\");");
+    println!("  ");
+    println!("  let placed_order = http_client.create_order(&order).await?;");
+    println!("  println!(\"Order placed: {{}}\", placed_order.id);");
+    println!("  println!(\"Status: {{:?}}\", placed_order.status);");
+
+    // Track order via WebSocket
+    println!("\n--- Track Order via WebSocket ---");
+    println!("  let order_id = placed_order.id.clone();");
+    println!("  ");
+    println!("  while let Some(update) = stream.next().await {{");
+    println!("      match update {{");
+    println!("          Ok(WebSocketMessage::TradeUpdate(trade_update)) => {{");
+    println!("              if trade_update.order.id == order_id {{");
+    println!("                  println!(\"Order Update:\");");
+    println!("                  println!(\"  Event: {{:?}}\", trade_update.event);");
+    println!("                  println!(\"  Status: {{:?}}\", trade_update.order.status);");
+    println!("                  println!(\"  Filled Qty: {{}}\", trade_update.order.filled_qty);");
+    println!("                  ");
+    println!("                  // Check if order is terminal");
+    println!("                  match trade_update.event {{");
+    println!("                      TradeUpdateEvent::Fill => {{");
+    println!("                          println!(\"Order filled completely!\");");
+    println!("                          break;");
+    println!("                      }}");
+    println!("                      TradeUpdateEvent::Canceled |");
+    println!("                      TradeUpdateEvent::Rejected |");
+    println!("                      TradeUpdateEvent::Expired => {{");
+    println!("                          println!(\"Order terminated: {{:?}}\", trade_update.event);");
+    println!("                          break;");
+    println!("                      }}");
+    println!("                      _ => {{}}");
+    println!("                  }}");
+    println!("              }}");
+    println!("          }}");
+    println!("          Err(e) => eprintln!(\"Error: {{}}\", e),");
+    println!("          _ => {{}}");
+    println!("      }}");
+    println!("  }}");
+
+    // Trade update events
+    println!("\n--- Trade Update Events ---");
+    println!("  New: Order accepted");
+    println!("  Fill: Order filled (partial or complete)");
+    println!("  PartialFill: Partial fill occurred");
+    println!("  Canceled: Order canceled");
+    println!("  Expired: Order expired");
+    println!("  Rejected: Order rejected");
+    println!("  PendingNew: Order pending acceptance");
+    println!("  PendingCancel: Cancel pending");
+    println!("  PendingReplace: Replace pending");
+    println!("  Replaced: Order replaced");
+
+    // Order state machine
+    println!("\n--- Order State Machine ---");
+    println!("  New -> PartialFill -> Fill (success)");
+    println!("  New -> Fill (immediate fill)");
+    println!("  New -> Canceled (user canceled)");
+    println!("  New -> Expired (time expired)");
+    println!("  New -> Rejected (validation failed)");
+
+    // Timeout handling
+    println!("\n--- Timeout Handling ---");
+    println!("  let timeout = Duration::from_secs(60);");
+    println!("  ");
+    println!("  tokio::select! {{");
+    println!("      result = track_order(&mut stream, &order_id) => {{");
+    println!("          println!(\"Order tracking complete: {{:?}}\", result);");
+    println!("      }}");
+    println!("      _ = tokio::time::sleep(timeout) => {{");
+    println!("          println!(\"Timeout waiting for order update\");");
+    println!("          // Optionally cancel the order");
+    println!("          http_client.cancel_order(&order_id).await?;");
+    println!("      }}");
+    println!("  }}");
+
+    // Best practices
+    println!("\n--- Best Practices ---");
+    println!("1. Always connect WebSocket before placing order");
+    println!("2. Handle all terminal states (fill, cancel, reject, expire)");
+    println!("3. Implement timeout for order tracking");
+    println!("4. Store order state for recovery");
+    println!("5. Log all order events for audit");
+
+    // Display example values
+    let _credentials = Credentials::paper("demo_key", "demo_secret");
+    let _environment = Environment::Paper;
+    let _side = OrderSide::Buy;
+    let _tif = TimeInForce::Day;
+
+    println!("\n=== Example Complete ===");
+}


### PR DESCRIPTION
Add 7 examples for Integration Bots & Strategies:

- integration_paper_trading_bot.rs: Simple paper trading bot
- integration_realtime_order_tracker.rs: Place order and track via WebSocket
- integration_historical_data_download.rs: Download and save historical bars
- integration_realtime_data_logger.rs: Log streaming data to file
- integration_bracket_order_with_updates.rs: Place bracket order and monitor
- integration_portfolio_rebalancer.rs: Rebalance portfolio to targets
- integration_options_scanner.rs: Scan and filter options

Also:
- Update root README with Bots & Strategies examples section

Closes #59